### PR TITLE
feat: support wasm target and frame tick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-targets --locked
+        run: cargo test --all-targets --all-features --locked
 
       - name: Build docs
-        run: cargo doc --no-deps --locked
+        run: cargo doc --no-deps --all-features --locked
 
   msrv:
     name: MSRV check
@@ -53,4 +53,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check crate on MSRV
-        run: cargo check --all-targets --locked
+        run: cargo check --all-targets --all-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,6 @@ dependencies = [
  "bevy_state",
  "bevy_time",
  "spacetimedb-sdk",
- "tracing",
  "wasm-bindgen-futures",
 ]
 
@@ -2889,37 +2888,6 @@ name = "toml_writer"
 version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "bevy_state",
  "bevy_time",
  "spacetimedb-sdk",
+ "tracing",
  "wasm-bindgen-futures",
 ]
 
@@ -2888,6 +2889,37 @@ name = "toml_writer"
 version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_stdb"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bevy_app",
  "bevy_ecs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "bevy_state",
  "bevy_time",
  "spacetimedb-sdk",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1141,9 +1142,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1166,6 +1169,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "gloo-console"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a17868f56b4a24f677b17c8cb69958385102fa879418052d60b50bc1727e261"
+dependencies = [
+ "gloo-utils",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-storage"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc8031e8c92758af912f9bc08fbbadd3c6f3cfcbf6b64cdf3d6a81f0139277a"
+dependencies = [
+ "gloo-utils",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2460,8 +2525,14 @@ dependencies = [
  "flate2",
  "futures",
  "futures-channel",
+ "getrandom 0.3.4",
+ "gloo-console",
+ "gloo-net",
+ "gloo-storage",
+ "gloo-utils",
  "home",
  "http",
+ "js-sys",
  "log",
  "native-tls",
  "once_cell",
@@ -2476,7 +2547,11 @@ dependencies = [
  "spacetimedb-schema",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.27.0",
+ "tokio-tungstenite-wasm",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2732,6 +2807,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
@@ -2741,7 +2828,26 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite-wasm"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4585aa997e4afb43c64f9101c27411b8e1bf9dde49b22e3e47acdde3055b325c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "httparse",
+ "js-sys",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2782,6 +2888,23 @@ name = "toml_writer"
 version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,12 @@ bevy_ecs = "0.18"
 bevy_state = "0.18"
 bevy_time = "0.18"
 spacetimedb-sdk = "2.1"
+wasm-bindgen-futures = { version = "0.4", optional = true }
 
 [features]
 default = []
+browser = ["spacetimedb-sdk/browser", "wasm-bindgen-futures"]
+
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ bevy_ecs = "0.18"
 bevy_state = "0.18"
 bevy_time = "0.18"
 spacetimedb-sdk = "2.1"
+tracing = { version = "0.1" }
 wasm-bindgen-futures = { version = "0.4", optional = true }
+
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_stdb"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.93"
 description = "A Bevy-native integration for SpacetimeDB with table messages, subscriptions, and reconnect support."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bevy_ecs = "0.18"
 bevy_state = "0.18"
 bevy_time = "0.18"
 spacetimedb-sdk = "2.1"
-tracing = { version = "0.1" }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fn on_player_info_insert(mut msgs: ReadInsertMessage<PlayerInfo>) {
 - `with_background_driver(...)`: start SpacetimeDB's background processing for the active connection
 - `with_frame_driver(...)`: drive SpacetimeDB from the Bevy schedule each frame
 
-These modes are mutually exclusive, typically you'll want to use `with_background_driver`. 
+Exactly one driver must be configured. These modes are mutually exclusive, and in most applications you'll want `with_background_driver(...)`.
 
 If WASM support is needed, you can enable the `browser` feature flag in both this crate and your `spacetimedb-sdk` crate using a target cfg:
 
@@ -159,7 +159,7 @@ fn main() {
 
 ### Bevy frame-tick driving
 
-Use `frame_tick` when you want Bevy to drive connection progress from Bevy's `Update` schedule:
+Use `frame_tick` when you want Bevy to drive connection progress from Bevy each frame. Internally, `bevy_stdb` runs this driver from `PreUpdate`:
 
 ```rust
 use bevy::prelude::*;

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ fn main() {
                     subs.subscribe_query(MySubKey::PlayerInfo, |q| q.from.player_info());
                 })
                 .with_reconnect(StdbReconnectOptions::default())
-                .with_run_background(DbConnection::run_threaded),
+                .with_background_driver(DbConnection::run_threaded),
         )
         .add_systems(Update, on_player_info_insert)
         .run();
@@ -83,20 +83,28 @@ fn on_player_info_insert(mut msgs: ReadInsertMessage<PlayerInfo>) {
 
 `bevy_stdb` supports two connection-driving modes:
 
-- `with_run_background(...)`: start SpacetimeDB's background processing for the active connection
-- `with_run_frame_tick(...)`: drive SpacetimeDB from the Bevy schedule each frame
+- `with_background_driver(...)`: start SpacetimeDB's background processing for the active connection
+- `with_frame_driver(...)`: drive SpacetimeDB from the Bevy schedule each frame
 
-These modes are mutually exclusive, typically you'll want to use `with_run_background`.
+These modes are mutually exclusive, typically you'll want to use `with_background_driver`. 
+
+If WASM support is needed, you can enable the `browser` feature flag in both this crate and your `spacetimedb-sdk` crate using a target cfg:
+
+```toml
+# Enable browser support for wasm builds.
+# Replace `*` with the versions you are using.
+[target.wasm32-unknown-unknown.dependencies]
+spacetimedb-sdk = { version = "*", features = ["browser"] }
+bevy_stdb = { version = "*", features = ["browser"] }
+```
+
+> I recommend checking out the [bevy_cli 2d template](https://github.com/TheBevyFlock/bevy_new_2d/) for a good starter example using WASM + native with nice Bevy features configured.
 
 ### Native background driving
 
 On native targets, the typical choice is `run_threaded`:
 
 ```rust
-use bevy::prelude::*;
-use bevy_stdb::prelude::*;
-use crate::module_bindings::{DbConnection, RemoteModule};
-
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -104,15 +112,54 @@ fn main() {
             StdbPlugin::<DbConnection, RemoteModule>::default()
                 .with_module_name("my_module")
                 .with_uri("http://localhost:3000")
-                .with_run_background(DbConnection::run_threaded),
+                .with_background_driver(DbConnection::run_threaded),
         )
         .run();
+}
+```
+
+### Browser / wasm background driving (async)
+
+On browser targets, use the generated background task helper instead:
+
+```rust
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(
+            StdbPlugin::<DbConnection, RemoteModule>::default()
+                .with_module_name("my_module")
+                .with_uri("http://localhost:3000")
+                .with_background_driver(DbConnection::run_background_task),
+        )
+        .run();
+}
+```
+
+If you target both native and browser, I recommend selecting the background driver with `cfg`:
+
+```rust
+fn main() {
+    let mut plugin = StdbPlugin::<DbConnection, RemoteModule>::default()
+        .with_module_name("my_module")
+        .with_uri("http://localhost:3000");
+    
+    #[cfg(target_arch = "wasm32")]
+    {
+        plugin = plugin.with_background_driver(DbConnection::run_background_task);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        plugin = plugin.with_background_driver(DbConnection::run_threaded);
+    }
+
+    App::new().add_plugins(DefaultPlugins).add_plugins(plugin).run();
 }
 ```
 
 ### Bevy frame-tick driving
 
-Use `frame_tick` when you want Bevy to drive connection progress from its normal schedule:
+Use `frame_tick` when you want Bevy to drive connection progress from Bevy's `Update` schedule:
 
 ```rust
 use bevy::prelude::*;
@@ -126,61 +173,9 @@ fn main() {
             StdbPlugin::<DbConnection, RemoteModule>::default()
                 .with_module_name("my_module")
                 .with_uri("http://localhost:3000")
-                .with_run_frame_tick(DbConnection::frame_tick),
+                .with_frame_driver(DbConnection::frame_tick),
         )
         .run();
-}
-```
-
-### Browser / wasm background driving
-
-On browser targets, use the generated background task helper instead:
-
-```rust
-use bevy::prelude::*;
-use bevy_stdb::prelude::*;
-use crate::module_bindings::{DbConnection, RemoteModule};
-
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugins(
-            StdbPlugin::<DbConnection, RemoteModule>::default()
-                .with_module_name("my_module")
-                .with_uri("http://localhost:3000")
-                .with_run_background(DbConnection::run_background_task),
-        )
-        .run();
-}
-```
-
-If you target both native and browser, selecting the background driver with `cfg` is a reasonable pattern:
-
-```rust
-use bevy::prelude::*;
-use bevy_stdb::prelude::*;
-use crate::module_bindings::{DbConnection, RemoteModule};
-
-fn main() {
-    let plugin = {
-        #[cfg(target_arch = "wasm32")]
-        {
-            StdbPlugin::<DbConnection, RemoteModule>::default()
-                .with_module_name("my_module")
-                .with_uri("http://localhost:3000")
-                .with_run_background(DbConnection::run_background_task)
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            StdbPlugin::<DbConnection, RemoteModule>::default()
-                .with_module_name("my_module")
-                .with_uri("http://localhost:3000")
-                .with_run_background(DbConnection::run_threaded)
-        }
-    };
-
-    App::new().add_plugins(DefaultPlugins).add_plugins(plugin).run();
 }
 ```
 
@@ -268,7 +263,7 @@ fn example_system(conn: Res<StdbConn>, mut subs: ResMut<StdbSubs>) {
 | bevy_stdb | bevy   | spacetimedb_sdk |
 | --------- | ------ | --------------- |
 | 0.1 - 0.2 | 0.18   | 2.0             |
-| 0.3       | 0.18   | 2.1             |
+| 0.3 - 0.4 | 0.18   | 2.1             |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ fn main() {
                     subs.subscribe_query(MySubKey::PlayerInfo, |q| q.from.player_info());
                 })
                 .with_reconnect(StdbReconnectOptions::default())
-                .with_run_fn(DbConnection::run_threaded),
+                .with_run_background(DbConnection::run_threaded),
         )
         .add_systems(Update, on_player_info_insert)
         .run();
@@ -76,6 +76,111 @@ fn on_player_info_insert(mut msgs: ReadInsertMessage<PlayerInfo>) {
     for msg in msgs.read() {
         info!("player inserted: {:?}", msg.row);
     }
+}
+```
+
+## Connection driving
+
+`bevy_stdb` supports two connection-driving modes:
+
+- `with_run_background(...)`: start SpacetimeDB's background processing for the active connection
+- `with_run_frame_tick(...)`: drive SpacetimeDB from the Bevy schedule each frame
+
+These modes are mutually exclusive, typically you'll want to use `with_run_background`.
+
+### Native background driving
+
+On native targets, the typical choice is `run_threaded`:
+
+```rust
+use bevy::prelude::*;
+use bevy_stdb::prelude::*;
+use crate::module_bindings::{DbConnection, RemoteModule};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(
+            StdbPlugin::<DbConnection, RemoteModule>::default()
+                .with_module_name("my_module")
+                .with_uri("http://localhost:3000")
+                .with_run_background(DbConnection::run_threaded),
+        )
+        .run();
+}
+```
+
+### Bevy frame-tick driving
+
+Use `frame_tick` when you want Bevy to drive connection progress from its normal schedule:
+
+```rust
+use bevy::prelude::*;
+use bevy_stdb::prelude::*;
+use crate::module_bindings::{DbConnection, RemoteModule};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(
+            StdbPlugin::<DbConnection, RemoteModule>::default()
+                .with_module_name("my_module")
+                .with_uri("http://localhost:3000")
+                .with_run_frame_tick(DbConnection::frame_tick),
+        )
+        .run();
+}
+```
+
+### Browser / wasm background driving
+
+On browser targets, use the generated background task helper instead:
+
+```rust
+use bevy::prelude::*;
+use bevy_stdb::prelude::*;
+use crate::module_bindings::{DbConnection, RemoteModule};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(
+            StdbPlugin::<DbConnection, RemoteModule>::default()
+                .with_module_name("my_module")
+                .with_uri("http://localhost:3000")
+                .with_run_background(DbConnection::run_background_task),
+        )
+        .run();
+}
+```
+
+If you target both native and browser, selecting the background driver with `cfg` is a reasonable pattern:
+
+```rust
+use bevy::prelude::*;
+use bevy_stdb::prelude::*;
+use crate::module_bindings::{DbConnection, RemoteModule};
+
+fn main() {
+    let plugin = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            StdbPlugin::<DbConnection, RemoteModule>::default()
+                .with_module_name("my_module")
+                .with_uri("http://localhost:3000")
+                .with_run_background(DbConnection::run_background_task)
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            StdbPlugin::<DbConnection, RemoteModule>::default()
+                .with_module_name("my_module")
+                .with_uri("http://localhost:3000")
+                .with_run_background(DbConnection::run_threaded)
+        }
+    };
+
+    App::new().add_plugins(DefaultPlugins).add_plugins(plugin).run();
 }
 ```
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -265,11 +265,11 @@ impl<
                 let pending_config = config.clone();
                 let (tx, rx) = channel();
 
-                println!("bevy_stdb: spawning initial browser connection task");
+                tracing::info!("bevy_stdb: spawning initial browser connection task");
                 wasm_bindgen_futures::spawn_local(async move {
-                    println!("bevy_stdb: initial browser connection task started");
+                    tracing::info!("bevy_stdb: initial browser connection task started");
                     let result = pending_config.build_connection().await;
-                    println!(
+                    tracing::info!(
                         "bevy_stdb: initial browser connection task completed: success={}",
                         result.is_ok()
                     );
@@ -319,12 +319,14 @@ impl<
         {
             let result = state.result.lock().unwrap_or_else(|e| e.into_inner());
             if result.is_some() {
-                println!("bevy_stdb: initial connection ready() returning true from cached result");
+                tracing::info!(
+                    "bevy_stdb: initial connection ready() returning true from cached result"
+                );
                 return true;
             }
         }
 
-        println!("bevy_stdb: initial connection ready() polling task");
+        tracing::info!("bevy_stdb: initial connection ready() polling task");
         let next_result = {
             let rx = state.rx.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -338,11 +340,11 @@ impl<
         };
 
         let Some(next_result) = next_result else {
-            println!("bevy_stdb: initial connection ready() still pending");
+            tracing::info!("bevy_stdb: initial connection ready() still pending");
             return false;
         };
 
-        println!(
+        tracing::info!(
             "bevy_stdb: initial connection ready() received completed task result: success={}",
             next_result.is_ok()
         );
@@ -354,7 +356,7 @@ impl<
 
     /// Establishes the initial connection and registers table handlers.
     fn finish(&self, app: &mut App) {
-        println!("bevy_stdb: plugin finish() finalizing initial connection");
+        tracing::info!("bevy_stdb: plugin finish() finalizing initial connection");
         let conn = {
             let state = app
                 .world_mut()
@@ -387,11 +389,11 @@ impl<
         }
 
         if let Some(background_driver) = background_driver {
-            println!("bevy_stdb: starting configured background driver");
+            tracing::info!("bevy_stdb: starting configured background driver");
             background_driver(conn.as_ref());
         }
         app.insert_resource(StdbConnection::new(conn));
-        println!("bevy_stdb: initial connection resource inserted");
+        tracing::info!("bevy_stdb: initial connection resource inserted");
     }
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -290,14 +290,8 @@ impl<
                 let pending_config = config.clone();
                 let (tx, rx) = channel();
 
-                tracing::info!("bevy_stdb: spawning initial browser connection task");
                 wasm_bindgen_futures::spawn_local(async move {
-                    tracing::info!("bevy_stdb: initial browser connection task started");
                     let result = pending_config.build_connection().await;
-                    tracing::info!(
-                        "bevy_stdb: initial browser connection task completed: success={}",
-                        result.is_ok()
-                    );
                     let _ = tx.send(result);
                 });
 
@@ -346,41 +340,22 @@ impl<
         let mut status = state.status.lock().unwrap_or_else(|e| e.into_inner());
 
         match &mut *status {
-            InitialConnectionStatus::Ready(_) => {
-                tracing::info!(
-                    "bevy_stdb: initial connection ready() returning true from cached result"
-                );
-                true
-            }
-            InitialConnectionStatus::Pending(rx) => {
-                tracing::info!("bevy_stdb: initial connection ready() polling task");
-
-                match rx.try_recv() {
-                    Ok(result) => {
-                        tracing::info!(
-                            "bevy_stdb: initial connection ready() received completed task result: success={}",
-                            result.is_ok()
-                        );
-                        *status = InitialConnectionStatus::Ready(result);
-                        true
-                    }
-                    Err(TryRecvError::Empty) => {
-                        tracing::info!("bevy_stdb: initial connection ready() still pending");
-                        false
-                    }
-                    Err(TryRecvError::Disconnected) => {
-                        panic!(
-                            "pending browser connection task disconnected before returning a result"
-                        )
-                    }
+            InitialConnectionStatus::Ready(_) => true,
+            InitialConnectionStatus::Pending(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    *status = InitialConnectionStatus::Ready(result);
+                    true
                 }
-            }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Disconnected) => {
+                    panic!("pending browser connection task disconnected before returning a result")
+                }
+            },
         }
     }
 
     /// Establishes the initial connection and registers table handlers.
     fn finish(&self, app: &mut App) {
-        tracing::info!("bevy_stdb: plugin finish() finalizing initial connection");
         let state = app
             .world_mut()
             .remove_resource::<InitialConnectionState<C>>()
@@ -410,12 +385,10 @@ impl<
         }
 
         if let Some(ConnectionDriver::Background(background_driver)) = driver {
-            tracing::info!("bevy_stdb: starting configured background driver");
             background_driver(conn.as_ref());
         }
 
         app.insert_resource(StdbConnection::new(conn));
-        tracing::info!("bevy_stdb: initial connection resource inserted");
     }
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -270,11 +270,9 @@ fn watch_connected<
     M: SpacetimeModule<DbConnection = C>,
 >(
     mut msgs: ReadStdbConnectedMessage,
-    mut config: ResMut<StdbConnectionConfig<C, M>>,
     mut next_state: ResMut<NextState<StdbConnectionState>>,
 ) {
-    for msg in msgs.read() {
-        config.token = Some(msg.access_token.clone());
+    for _ in msgs.read() {
         next_state.set(StdbConnectionState::Connected);
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
     system::{Res, ResMut},
 };
 use bevy_state::{
-    app::{AppExtStates, StatesPlugin},
+    app::AppExtStates,
     condition::in_state,
     state::{NextState, OnEnter, States},
 };
@@ -24,10 +24,9 @@ use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     Compression, ConnectionId, DbConnectionBuilder, DbContext, Identity, Result,
 };
-use std::sync::{Arc, Mutex, mpsc::Sender};
-
 #[cfg(feature = "browser")]
-use std::sync::mpsc::{Receiver, channel};
+use std::sync::mpsc::{Receiver, TryRecvError, channel};
+use std::sync::{Arc, Mutex, mpsc::Sender};
 
 #[derive(Resource)]
 struct InitialConnectionState<C: DbContext + Send + Sync + 'static> {
@@ -106,6 +105,7 @@ where
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
 {
+    /// Internal helper to build the [`DbConnectionBuilder`] for this connection, shared across targets.
     fn connection_builder(&self) -> DbConnectionBuilder<M> {
         let connected_tx = self.connected_tx.clone();
         let disconnected_tx = self.disconnected_tx.clone();
@@ -130,7 +130,7 @@ where
             })
     }
 
-    /// Builds a SpacetimeDB connection from this config.
+    /// Synchronously builds a SpacetimeDB connection from this config.
     ///
     /// The returned connection is not started automatically.
     #[cfg(not(feature = "browser"))]
@@ -138,7 +138,7 @@ where
         self.connection_builder().build().map(Arc::new)
     }
 
-    /// Builds a SpacetimeDB connection from this config.
+    /// Asynchronously builds a SpacetimeDB connection from this config.
     ///
     /// The returned connection is not started automatically.
     #[cfg(feature = "browser")]
@@ -241,9 +241,6 @@ impl<
 {
     /// Initializes connection state, resources, and lifecycle systems.
     fn build(&self, app: &mut App) {
-        if !app.is_plugin_added::<StatesPlugin>() {
-            app.add_plugins(StatesPlugin);
-        }
         app.init_state::<StdbConnectionState>();
 
         let config = StdbConnectionConfig::<C, M> {
@@ -293,20 +290,24 @@ impl<
         app.insert_resource(config);
         app.insert_resource(initial_connection_state);
 
-        app.add_systems(
-            PreUpdate,
-            (
-                watch_connected::<C, M>,
-                watch_disconnected,
-                watch_connection_error,
-                drive_connection_frame_tick::<C, M>
-                    .run_if(in_state(StdbConnectionState::Connected)),
-            ),
-        );
+        // Set our StdbConnectionState based on the connection state messages from SpacetimeDB.
+        app.add_systems(PreUpdate, sync_connection_state);
+
+        // Bind table callbacks when a new connection is established.
         app.add_systems(
             OnEnter(StdbConnectionState::Connected),
             on_connected_bind::<C, M>,
         );
+
+        // We only need this system if frame_tick is configured, which is a build time concern. The driver
+        // shouldn't be changed at runtime so a run condition makes less sense here.
+        if self.frame_tick.is_some() {
+            app.add_systems(
+                PreUpdate,
+                drive_connection_frame_tick::<C, M>
+                    .run_if(in_state(StdbConnectionState::Connected)),
+            );
+        }
     }
 
     #[cfg(feature = "browser")]
@@ -332,8 +333,9 @@ impl<
 
             match rx.try_recv() {
                 Ok(result) => Some(result),
-                Err(std::sync::mpsc::TryRecvError::Empty) => None,
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                Err(TryRecvError::Empty) => None,
+                Err(TryRecvError::Disconnected) => {
+                    // TBD on whether a panic makes sense here...
                     panic!("pending browser connection task disconnected before returning a result")
                 }
             }
@@ -357,33 +359,26 @@ impl<
     /// Establishes the initial connection and registers table handlers.
     fn finish(&self, app: &mut App) {
         tracing::info!("bevy_stdb: plugin finish() finalizing initial connection");
-        let conn = {
-            let state = app
-                .world_mut()
-                .remove_resource::<InitialConnectionState<C>>()
-                .expect("InitialConnectionState should exist before plugin finish");
+        let state = app
+            .world_mut()
+            .remove_resource::<InitialConnectionState<C>>()
+            .expect("InitialConnectionState should exist before plugin finish");
+        let conn = state
+            .result
+            .into_inner()
+            .unwrap_or_else(|e| e.into_inner())
+            .expect("plugin finish should only run after ready() returns true")
+            .expect("Failed to establish initial connection");
 
-            state
-                .result
-                .into_inner()
-                .unwrap_or_else(|e| e.into_inner())
-                .expect("plugin finish should only run after ready() returns true")
-                .expect("Failed to establish initial connection")
-        };
+        let config = app
+            .world()
+            .get_resource::<StdbConnectionConfig<C, M>>()
+            .expect("StdbConnectionConfig should be inserted during plugin build");
 
-        let (table_registrar, background_driver) = {
-            let config = app
-                .world()
-                .get_resource::<StdbConnectionConfig<C, M>>()
-                .expect("StdbConnectionConfig should be inserted during plugin build");
+        let table_registrar = config.table_registrar.clone();
+        let background_driver = config.background_driver.clone();
 
-            (
-                config.table_registrar.clone(),
-                config.background_driver.clone(),
-            )
-        };
-
-        if let Some(register) = &table_registrar {
+        if let Some(register) = table_registrar {
             let db = conn.db();
             register(&mut TableRegistrar::new_init(app), db);
         }
@@ -392,41 +387,32 @@ impl<
             tracing::info!("bevy_stdb: starting configured background driver");
             background_driver(conn.as_ref());
         }
+
         app.insert_resource(StdbConnection::new(conn));
         tracing::info!("bevy_stdb: initial connection resource inserted");
     }
 }
 
-fn watch_connected<
-    C: DbConnection<Module = M> + DbContext + Send + Sync,
-    M: SpacetimeModule<DbConnection = C>,
->(
-    mut msgs: ReadStdbConnectedMessage,
+/// Synchronizes the connection state based on the connection state messages from SpacetimeDB.
+/// Disconnected state takes precedence over connected state in ambiguous cases (multiple events per frame)
+fn sync_connection_state(
+    mut connected_msgs: ReadStdbConnectedMessage,
+    mut disconnected_msgs: ReadStdbDisconnectedMessage,
+    mut connection_error_msgs: ReadStdbConnectionErrorMessage,
     mut next_state: ResMut<NextState<StdbConnectionState>>,
 ) {
-    for _ in msgs.read() {
+    if connected_msgs.read().count() > 0 {
         next_state.set(StdbConnectionState::Connected);
     }
-}
-
-fn watch_disconnected(
-    mut msgs: ReadStdbDisconnectedMessage,
-    mut next_state: ResMut<NextState<StdbConnectionState>>,
-) {
-    for _ in msgs.read() {
+    if disconnected_msgs.read().count() > 0 {
+        next_state.set(StdbConnectionState::Disconnected);
+    }
+    if connection_error_msgs.read().count() > 0 {
         next_state.set(StdbConnectionState::Disconnected);
     }
 }
 
-fn watch_connection_error(
-    mut msgs: ReadStdbConnectionErrorMessage,
-    mut next_state: ResMut<NextState<StdbConnectionState>>,
-) {
-    for _ in msgs.read() {
-        next_state.set(StdbConnectionState::Disconnected);
-    }
-}
-
+/// Bind the table callbacks when a new connection is established.
 fn on_connected_bind<
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
@@ -446,6 +432,8 @@ fn on_connected_bind<
     }
 }
 
+/// "tick" the connection frame, driving any pending operations. This is only used when the driver is `frame_tick`.
+/// Uncommon use case, but its available when you want to have events processed at the bevy frame rate.
 fn drive_connection_frame_tick<
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
@@ -453,9 +441,6 @@ fn drive_connection_frame_tick<
     conn: Res<StdbConnection<C>>,
     config: Res<StdbConnectionConfig<C, M>>,
 ) {
-    let Some(frame_tick) = config.frame_tick else {
-        return;
-    };
-
+    let frame_tick = config.frame_tick.expect("frame_tick is not configured");
     let _ = frame_tick(conn.conn.as_ref());
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -11,20 +11,18 @@ use crate::{
     table::{TableRegistrar, TableRegistrarCallback},
 };
 use bevy_app::{App, Plugin, PreUpdate};
-use bevy_ecs::{resource::Resource, system::ResMut};
+use bevy_ecs::{resource::Resource, schedule::IntoScheduleConfigs, system::ResMut};
 
 use bevy_state::{
     app::{AppExtStates, StatesPlugin},
+    condition::in_state,
     state::{NextState, OnEnter, States},
 };
 use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     Compression, ConnectionId, DbConnectionBuilder, DbContext, Identity, Result,
 };
-use std::{
-    sync::{Arc, mpsc::Sender},
-    thread::JoinHandle,
-};
+use std::sync::{Arc, mpsc::Sender};
 
 /// Lifecycle state for the active SpacetimeDB connection.
 #[derive(States, Debug, Default, Clone, PartialEq, Eq, Hash)]
@@ -58,8 +56,10 @@ pub(crate) struct StdbConnectionConfig<
     pub uri: String,
     /// Optional authentication token.
     pub token: Option<String>,
-    /// The function used to drive the connection.
-    pub run_fn: fn(&C) -> JoinHandle<()>,
+    /// The function used to drive the connection from the Bevy schedule.
+    pub frame_tick: Option<fn(&C) -> Result<()>>,
+    /// The function used to start background connection processing.
+    pub background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
     /// Compression configuration for the connection.
     pub compression: Compression,
     /// Stored table registration closure for init and bind.
@@ -184,8 +184,10 @@ pub(crate) struct StdbConnectionPlugin<
     pub uri: String,
     /// Optional authentication token.
     pub token: Option<String>,
-    /// The function used to drive the connection.
-    pub run_fn: fn(&C) -> JoinHandle<()>,
+    /// The function used to drive the connection from the Bevy schedule.
+    pub frame_tick: Option<fn(&C) -> Result<()>>,
+    /// The function used to start background connection processing.
+    pub background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
     /// Compression configuration for the connection.
     pub compression: Compression,
     /// Stored table registration closure for init and bind.
@@ -206,7 +208,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             module_name: self.module_name.clone(),
             uri: self.uri.clone(),
             token: self.token.clone(),
-            run_fn: self.run_fn,
+            frame_tick: self.frame_tick,
+            background_driver: self.background_driver.clone(),
             compression: self.compression,
             table_registrar: self.table_registrar.clone(),
             connected_tx: register_channel::<StdbConnectedMessage>(app),
@@ -217,7 +220,13 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
         app.add_systems(
             PreUpdate,
-            (watch_connected, watch_disconnected, watch_connection_error),
+            (
+                watch_connected::<C, M>,
+                watch_disconnected,
+                watch_connection_error,
+                drive_connection_frame_tick::<C, M>
+                    .run_if(in_state(StdbConnectionState::Connected)),
+            ),
         );
         app.add_systems(
             OnEnter(StdbConnectionState::Connected),
@@ -227,7 +236,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Establishes the initial connection and registers table handlers.
     fn finish(&self, app: &mut App) {
-        let (conn, table_registrar, run_fn) = {
+        let (conn, table_registrar, background_driver) = {
             let config = app
                 .world()
                 .get_resource::<StdbConnectionConfig<C, M>>()
@@ -237,7 +246,11 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
                 .build_connection()
                 .expect("Failed to establish initial connection");
 
-            (conn, config.table_registrar.clone(), config.run_fn)
+            (
+                conn,
+                config.table_registrar.clone(),
+                config.background_driver.clone(),
+            )
         };
 
         if let Some(register) = &table_registrar {
@@ -245,16 +258,23 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             register(&mut TableRegistrar::new_init(app), db);
         }
 
-        run_fn(conn.as_ref());
+        if let Some(background_driver) = background_driver {
+            background_driver(conn.as_ref());
+        }
         app.insert_resource(StdbConnection::new(conn));
     }
 }
 
-fn watch_connected(
+fn watch_connected<
+    C: DbConnection<Module = M> + DbContext + Send + Sync,
+    M: SpacetimeModule<DbConnection = C>,
+>(
     mut msgs: ReadStdbConnectedMessage,
+    mut config: ResMut<StdbConnectionConfig<C, M>>,
     mut next_state: ResMut<NextState<StdbConnectionState>>,
 ) {
-    for _ in msgs.read() {
+    for msg in msgs.read() {
+        config.token = Some(msg.access_token.clone());
         next_state.set(StdbConnectionState::Connected);
     }
 }
@@ -294,4 +314,18 @@ fn on_connected_bind<
     if let Some(register) = &config.table_registrar {
         register(&mut TableRegistrar::new_bind(&*world), db);
     }
+}
+
+fn drive_connection_frame_tick<
+    C: DbConnection<Module = M> + DbContext + Send + Sync,
+    M: SpacetimeModule<DbConnection = C>,
+>(
+    conn: bevy_ecs::system::Res<StdbConnection<C>>,
+    config: bevy_ecs::system::Res<StdbConnectionConfig<C, M>>,
+) {
+    let Some(frame_tick) = config.frame_tick else {
+        return;
+    };
+
+    let _ = frame_tick(conn.conn.as_ref());
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,6 @@
 //! Connection state and resources.
 //!
 //! This module manages the active connection and its Bevy lifecycle integration.
-
 use crate::{
     alias::{
         ReadStdbConnectedMessage, ReadStdbConnectionErrorMessage, ReadStdbDisconnectedMessage,
@@ -25,7 +24,17 @@ use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     Compression, ConnectionId, DbConnectionBuilder, DbContext, Identity, Result,
 };
-use std::sync::{Arc, mpsc::Sender};
+use std::sync::{Arc, Mutex, mpsc::Sender};
+
+#[cfg(feature = "browser")]
+use std::sync::mpsc::{Receiver, channel};
+
+#[derive(Resource)]
+struct InitialConnectionState<C: DbContext + Send + Sync + 'static> {
+    result: Mutex<Option<Result<Arc<C>>>>,
+    #[cfg(feature = "browser")]
+    rx: Mutex<Receiver<Result<Arc<C>>>>,
+}
 
 /// Lifecycle state for the active SpacetimeDB connection.
 #[derive(States, Debug, Default, Clone, PartialEq, Eq, Hash)]
@@ -44,7 +53,7 @@ pub enum StdbConnectionState {
 }
 
 /// Runtime configuration for the active SpacetimeDB connection.
-#[derive(Resource, Clone)]
+#[derive(Resource)]
 pub(crate) struct StdbConnectionConfig<
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
@@ -71,15 +80,33 @@ pub(crate) struct StdbConnectionConfig<
     pub error_tx: Sender<StdbConnectionErrorMessage>,
 }
 
+impl<C, M> Clone for StdbConnectionConfig<C, M>
+where
+    C: DbConnection<Module = M> + DbContext + Send + Sync,
+    M: SpacetimeModule<DbConnection = C>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            module_name: self.module_name.clone(),
+            uri: self.uri.clone(),
+            token: self.token.clone(),
+            frame_tick: self.frame_tick,
+            background_driver: self.background_driver.clone(),
+            compression: self.compression,
+            table_registrar: self.table_registrar.clone(),
+            connected_tx: self.connected_tx.clone(),
+            disconnected_tx: self.disconnected_tx.clone(),
+            error_tx: self.error_tx.clone(),
+        }
+    }
+}
+
 impl<C, M> StdbConnectionConfig<C, M>
 where
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
 {
-    /// Builds a SpacetimeDB connection from this config.
-    ///
-    /// The returned connection is not started automatically.
-    pub(crate) fn build_connection(&self) -> Result<Arc<C>> {
+    fn connection_builder(&self) -> DbConnectionBuilder<M> {
         let connected_tx = self.connected_tx.clone();
         let disconnected_tx = self.disconnected_tx.clone();
         let error_tx = self.error_tx.clone();
@@ -101,8 +128,22 @@ where
             .on_connect_error(move |_ctx, err| {
                 let _ = error_tx.send(StdbConnectionErrorMessage { err });
             })
-            .build()
-            .map(Arc::new)
+    }
+
+    /// Builds a SpacetimeDB connection from this config.
+    ///
+    /// The returned connection is not started automatically.
+    #[cfg(not(feature = "browser"))]
+    pub(crate) fn build_connection(&self) -> Result<Arc<C>> {
+        self.connection_builder().build().map(Arc::new)
+    }
+
+    /// Builds a SpacetimeDB connection from this config.
+    ///
+    /// The returned connection is not started automatically.
+    #[cfg(feature = "browser")]
+    pub(crate) async fn build_connection(&self) -> Result<Arc<C>> {
+        self.connection_builder().build().await.map(Arc::new)
     }
 }
 
@@ -193,8 +234,10 @@ pub(crate) struct StdbConnectionPlugin<
     pub table_registrar: Option<Arc<TableRegistrarCallback<C>>>,
 }
 
-impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<DbConnection = C>>
-    Plugin for StdbConnectionPlugin<C, M>
+impl<
+    C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
+    M: SpacetimeModule<DbConnection = C> + 'static,
+> Plugin for StdbConnectionPlugin<C, M>
 {
     /// Initializes connection state, resources, and lifecycle systems.
     fn build(&self, app: &mut App) {
@@ -215,7 +258,40 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             disconnected_tx: register_channel::<StdbDisconnectedMessage>(app),
             error_tx: register_channel::<StdbConnectionErrorMessage>(app),
         };
+
+        let initial_connection_state = {
+            #[cfg(feature = "browser")]
+            {
+                let pending_config = config.clone();
+                let (tx, rx) = channel();
+
+                println!("bevy_stdb: spawning initial browser connection task");
+                wasm_bindgen_futures::spawn_local(async move {
+                    println!("bevy_stdb: initial browser connection task started");
+                    let result = pending_config.build_connection().await;
+                    println!(
+                        "bevy_stdb: initial browser connection task completed: success={}",
+                        result.is_ok()
+                    );
+                    let _ = tx.send(result);
+                });
+
+                InitialConnectionState::<C> {
+                    result: Mutex::new(None),
+                    rx: Mutex::new(rx),
+                }
+            }
+
+            #[cfg(not(feature = "browser"))]
+            {
+                InitialConnectionState::<C> {
+                    result: Mutex::new(Some(config.build_connection())),
+                }
+            }
+        };
+
         app.insert_resource(config);
+        app.insert_resource(initial_connection_state);
 
         app.add_systems(
             PreUpdate,
@@ -233,20 +309,73 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         );
     }
 
+    #[cfg(feature = "browser")]
+    fn ready(&self, app: &App) -> bool {
+        let state = app
+            .world()
+            .get_resource::<InitialConnectionState<C>>()
+            .expect("InitialConnectionState should be inserted during plugin build");
+
+        {
+            let result = state.result.lock().unwrap_or_else(|e| e.into_inner());
+            if result.is_some() {
+                println!("bevy_stdb: initial connection ready() returning true from cached result");
+                return true;
+            }
+        }
+
+        println!("bevy_stdb: initial connection ready() polling task");
+        let next_result = {
+            let rx = state.rx.lock().unwrap_or_else(|e| e.into_inner());
+
+            match rx.try_recv() {
+                Ok(result) => Some(result),
+                Err(std::sync::mpsc::TryRecvError::Empty) => None,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    panic!("pending browser connection task disconnected before returning a result")
+                }
+            }
+        };
+
+        let Some(next_result) = next_result else {
+            println!("bevy_stdb: initial connection ready() still pending");
+            return false;
+        };
+
+        println!(
+            "bevy_stdb: initial connection ready() received completed task result: success={}",
+            next_result.is_ok()
+        );
+
+        let mut result = state.result.lock().unwrap_or_else(|e| e.into_inner());
+        *result = Some(next_result);
+        true
+    }
+
     /// Establishes the initial connection and registers table handlers.
     fn finish(&self, app: &mut App) {
-        let (conn, table_registrar, background_driver) = {
+        println!("bevy_stdb: plugin finish() finalizing initial connection");
+        let conn = {
+            let state = app
+                .world_mut()
+                .remove_resource::<InitialConnectionState<C>>()
+                .expect("InitialConnectionState should exist before plugin finish");
+
+            state
+                .result
+                .into_inner()
+                .unwrap_or_else(|e| e.into_inner())
+                .expect("plugin finish should only run after ready() returns true")
+                .expect("Failed to establish initial connection")
+        };
+
+        let (table_registrar, background_driver) = {
             let config = app
                 .world()
                 .get_resource::<StdbConnectionConfig<C, M>>()
                 .expect("StdbConnectionConfig should be inserted during plugin build");
 
-            let conn = config
-                .build_connection()
-                .expect("Failed to establish initial connection");
-
             (
-                conn,
                 config.table_registrar.clone(),
                 config.background_driver.clone(),
             )
@@ -258,9 +387,11 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         }
 
         if let Some(background_driver) = background_driver {
+            println!("bevy_stdb: starting configured background driver");
             background_driver(conn.as_ref());
         }
         app.insert_resource(StdbConnection::new(conn));
+        println!("bevy_stdb: initial connection resource inserted");
     }
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -65,6 +65,14 @@ pub enum StdbConnectionState {
     Exhausted,
 }
 
+/// Internal connection driver configuration.
+pub(crate) enum ConnectionDriver<C: DbContext + Send + Sync + 'static> {
+    /// Drive the connection from the Bevy schedule each frame.
+    FrameTick(fn(&C) -> Result<()>),
+    /// Start connection processing in the background.
+    Background(Arc<dyn Fn(&C) + Send + Sync>),
+}
+
 /// Runtime configuration for the active SpacetimeDB connection.
 #[derive(Resource)]
 pub(crate) struct StdbConnectionConfig<
@@ -77,10 +85,8 @@ pub(crate) struct StdbConnectionConfig<
     pub uri: String,
     /// Optional authentication token.
     pub token: Option<String>,
-    /// The function used to drive the connection from the Bevy schedule.
-    pub frame_tick: Option<fn(&C) -> Result<()>>,
-    /// The function used to start background connection processing.
-    pub background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
+    /// The configured connection driver.
+    pub driver: Option<ConnectionDriver<C>>,
     /// Compression configuration for the connection.
     pub compression: Compression,
     /// Stored table registration closure for init and bind.
@@ -93,6 +99,18 @@ pub(crate) struct StdbConnectionConfig<
     pub error_tx: Sender<StdbConnectionErrorMessage>,
 }
 
+impl<C> Clone for ConnectionDriver<C>
+where
+    C: DbContext + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::FrameTick(frame_tick) => Self::FrameTick(*frame_tick),
+            Self::Background(background_driver) => Self::Background(background_driver.clone()),
+        }
+    }
+}
+
 impl<C, M> Clone for StdbConnectionConfig<C, M>
 where
     C: DbConnection<Module = M> + DbContext + Send + Sync,
@@ -103,8 +121,7 @@ where
             module_name: self.module_name.clone(),
             uri: self.uri.clone(),
             token: self.token.clone(),
-            frame_tick: self.frame_tick,
-            background_driver: self.background_driver.clone(),
+            driver: self.driver.clone(),
             compression: self.compression,
             table_registrar: self.table_registrar.clone(),
             connected_tx: self.connected_tx.clone(),
@@ -238,10 +255,8 @@ pub(crate) struct StdbConnectionPlugin<
     pub uri: String,
     /// Optional authentication token.
     pub token: Option<String>,
-    /// The function used to drive the connection from the Bevy schedule.
-    pub frame_tick: Option<fn(&C) -> Result<()>>,
-    /// The function used to start background connection processing.
-    pub background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
+    /// The configured connection driver.
+    pub driver: Option<ConnectionDriver<C>>,
     /// Compression configuration for the connection.
     pub compression: Compression,
     /// Stored table registration closure for init and bind.
@@ -261,8 +276,7 @@ impl<
             module_name: self.module_name.clone(),
             uri: self.uri.clone(),
             token: self.token.clone(),
-            frame_tick: self.frame_tick,
-            background_driver: self.background_driver.clone(),
+            driver: self.driver.clone(),
             compression: self.compression,
             table_registrar: self.table_registrar.clone(),
             connected_tx: register_channel::<StdbConnectedMessage>(app),
@@ -312,9 +326,8 @@ impl<
             on_connected_bind::<C, M>,
         );
 
-        // We only need this system if frame_tick is configured, which is a build time concern. The driver
-        // shouldn't be changed at runtime so a run condition makes less sense here.
-        if self.frame_tick.is_some() {
+        // We only need this system if frame tick driving is configured, which is a build time concern.
+        if matches!(self.driver, Some(ConnectionDriver::FrameTick(_))) {
             app.add_systems(
                 PreUpdate,
                 drive_connection_frame_tick::<C, M>
@@ -389,14 +402,14 @@ impl<
             .expect("StdbConnectionConfig should be inserted during plugin build");
 
         let table_registrar = config.table_registrar.clone();
-        let background_driver = config.background_driver.clone();
+        let driver = config.driver.clone();
 
         if let Some(register) = table_registrar {
             let db = conn.db();
             register(&mut TableRegistrar::new_init(app), db);
         }
 
-        if let Some(background_driver) = background_driver {
+        if let Some(ConnectionDriver::Background(background_driver)) = driver {
             tracing::info!("bevy_stdb: starting configured background driver");
             background_driver(conn.as_ref());
         }
@@ -454,6 +467,13 @@ fn drive_connection_frame_tick<
     conn: Res<StdbConnection<C>>,
     config: Res<StdbConnectionConfig<C, M>>,
 ) {
-    let frame_tick = config.frame_tick.expect("frame_tick is not configured");
+    let ConnectionDriver::FrameTick(frame_tick) = config
+        .driver
+        .as_ref()
+        .expect("frame tick system should only be added when a driver is configured")
+    else {
+        panic!("frame tick system should only be added when the frame tick driver is configured");
+    };
+
     let _ = frame_tick(conn.conn.as_ref());
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -11,8 +11,11 @@ use crate::{
     table::{TableRegistrar, TableRegistrarCallback},
 };
 use bevy_app::{App, Plugin, PreUpdate};
-use bevy_ecs::{resource::Resource, schedule::IntoScheduleConfigs, system::ResMut};
-
+use bevy_ecs::{
+    resource::Resource,
+    schedule::IntoScheduleConfigs,
+    system::{Res, ResMut},
+};
 use bevy_state::{
     app::{AppExtStates, StatesPlugin},
     condition::in_state,
@@ -30,16 +33,12 @@ pub enum StdbConnectionState {
     /// The plugin hasn't initialized yet.
     #[default]
     Uninitialized,
-
     /// The connection is active.
     Connected,
-
     /// The connection is not active.
     Disconnected,
-
     /// A reconnect attempt is in progress.
     Reconnecting,
-
     /// Reconnect attempts have been exhausted.
     Exhausted,
 }
@@ -318,8 +317,8 @@ fn drive_connection_frame_tick<
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
 >(
-    conn: bevy_ecs::system::Res<StdbConnection<C>>,
-    config: bevy_ecs::system::Res<StdbConnectionConfig<C, M>>,
+    conn: Res<StdbConnection<C>>,
+    config: Res<StdbConnectionConfig<C, M>>,
 ) {
     let Some(frame_tick) = config.frame_tick else {
         return;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -28,11 +28,25 @@ use spacetimedb_sdk::{
 use std::sync::mpsc::{Receiver, TryRecvError, channel};
 use std::sync::{Arc, Mutex, mpsc::Sender};
 
+/// Internal startup status for the initial SpacetimeDB connection.
+///
+/// On native targets this begins in the ready state with the completed
+/// initial connection result. On browser targets it begins pending and
+/// transitions to ready once [`Plugin::ready`] observes the async result.
+enum InitialConnectionStatus<C: DbContext + Send + Sync + 'static> {
+    Ready(Result<Arc<C>>),
+    #[cfg(feature = "browser")]
+    Pending(Receiver<Result<Arc<C>>>),
+}
+
+/// Internal startup state for the initial SpacetimeDB connection.
+///
+/// This wraps the current startup status in interior mutability so
+/// [`Plugin::ready`] can advance browser initialization before
+/// [`Plugin::finish`] finalizes insertion of the live [`StdbConnection`] resource.
 #[derive(Resource)]
 struct InitialConnectionState<C: DbContext + Send + Sync + 'static> {
-    result: Mutex<Option<Result<Arc<C>>>>,
-    #[cfg(feature = "browser")]
-    rx: Mutex<Receiver<Result<Arc<C>>>>,
+    status: Mutex<InitialConnectionStatus<C>>,
 }
 
 /// Lifecycle state for the active SpacetimeDB connection.
@@ -274,15 +288,14 @@ impl<
                 });
 
                 InitialConnectionState::<C> {
-                    result: Mutex::new(None),
-                    rx: Mutex::new(rx),
+                    status: Mutex::new(InitialConnectionStatus::Pending(rx)),
                 }
             }
 
             #[cfg(not(feature = "browser"))]
             {
                 InitialConnectionState::<C> {
-                    result: Mutex::new(Some(config.build_connection())),
+                    status: Mutex::new(InitialConnectionStatus::Ready(config.build_connection())),
                 }
             }
         };
@@ -317,43 +330,39 @@ impl<
             .get_resource::<InitialConnectionState<C>>()
             .expect("InitialConnectionState should be inserted during plugin build");
 
-        {
-            let result = state.result.lock().unwrap_or_else(|e| e.into_inner());
-            if result.is_some() {
+        let mut status = state.status.lock().unwrap_or_else(|e| e.into_inner());
+
+        match &mut *status {
+            InitialConnectionStatus::Ready(_) => {
                 tracing::info!(
                     "bevy_stdb: initial connection ready() returning true from cached result"
                 );
-                return true;
+                true
             }
-        }
+            InitialConnectionStatus::Pending(rx) => {
+                tracing::info!("bevy_stdb: initial connection ready() polling task");
 
-        tracing::info!("bevy_stdb: initial connection ready() polling task");
-        let next_result = {
-            let rx = state.rx.lock().unwrap_or_else(|e| e.into_inner());
-
-            match rx.try_recv() {
-                Ok(result) => Some(result),
-                Err(TryRecvError::Empty) => None,
-                Err(TryRecvError::Disconnected) => {
-                    // TBD on whether a panic makes sense here...
-                    panic!("pending browser connection task disconnected before returning a result")
+                match rx.try_recv() {
+                    Ok(result) => {
+                        tracing::info!(
+                            "bevy_stdb: initial connection ready() received completed task result: success={}",
+                            result.is_ok()
+                        );
+                        *status = InitialConnectionStatus::Ready(result);
+                        true
+                    }
+                    Err(TryRecvError::Empty) => {
+                        tracing::info!("bevy_stdb: initial connection ready() still pending");
+                        false
+                    }
+                    Err(TryRecvError::Disconnected) => {
+                        panic!(
+                            "pending browser connection task disconnected before returning a result"
+                        )
+                    }
                 }
             }
-        };
-
-        let Some(next_result) = next_result else {
-            tracing::info!("bevy_stdb: initial connection ready() still pending");
-            return false;
-        };
-
-        tracing::info!(
-            "bevy_stdb: initial connection ready() received completed task result: success={}",
-            next_result.is_ok()
-        );
-
-        let mut result = state.result.lock().unwrap_or_else(|e| e.into_inner());
-        *result = Some(next_result);
-        true
+        }
     }
 
     /// Establishes the initial connection and registers table handlers.
@@ -363,12 +372,16 @@ impl<
             .world_mut()
             .remove_resource::<InitialConnectionState<C>>()
             .expect("InitialConnectionState should exist before plugin finish");
-        let conn = state
-            .result
-            .into_inner()
-            .unwrap_or_else(|e| e.into_inner())
-            .expect("plugin finish should only run after ready() returns true")
-            .expect("Failed to establish initial connection");
+
+        let conn = match state.status.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            InitialConnectionStatus::Ready(result) => {
+                result.expect("Failed to establish initial connection")
+            }
+            #[cfg(feature = "browser")]
+            InitialConnectionStatus::Pending(_) => {
+                panic!("plugin finish should only run after ready() returns true")
+            }
+        };
 
         let config = app
             .world()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ pub mod prelude {
             ReadUpdateMessage,
         },
         connection::{StdbConnection, StdbConnectionState},
+        message::{
+            DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
+            StdbConnectionErrorMessage, StdbDisconnectedMessage, UpdateMessage,
+        },
         plugin::StdbPlugin,
         reconnect::StdbReconnectOptions,
         subscription::StdbSubscriptions,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,12 +23,17 @@ pub struct StdbPlugin<
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
 > {
+    // Built-in SpacetimeDB fields
     module_name: Option<String>,
     uri: Option<String>,
     token: Option<String>,
-    frame_tick: Option<fn(&C) -> spacetimedb_sdk::Result<()>>,
-    background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
     compression: Option<Compression>,
+
+    // Options for how to process events from the websocket
+    frame_tick_driver: Option<fn(&C) -> spacetimedb_sdk::Result<()>>,
+    background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
+
+    // Custom options for reconnect and safely storing sub/table information
     reconnect_options: Option<StdbReconnectOptions>,
     subscriptions_initializer: Option<Arc<SubscriptionsInitializer>>,
     table_registrar: Option<Arc<TableRegistrarCallback<C>>>,
@@ -42,7 +47,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             module_name: None,
             uri: None,
             token: None,
-            frame_tick: None,
+            frame_tick_driver: None,
             background_driver: None,
             compression: None,
             reconnect_options: None,
@@ -61,14 +66,14 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>,
     ) -> Self {
         assert!(
-            self.frame_tick.is_none(),
+            self.frame_tick_driver.is_none(),
             "`with_run_frame_tick()` may only be called once"
         );
         assert!(
             self.background_driver.is_none(),
             "`with_run_frame_tick()` cannot be used after `with_run_background()`"
         );
-        self.frame_tick = Some(frame_tick);
+        self.frame_tick_driver = Some(frame_tick);
         self
     }
 
@@ -82,7 +87,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             "`with_run_background()` may only be called once"
         );
         assert!(
-            self.frame_tick.is_none(),
+            self.frame_tick_driver.is_none(),
             "`with_run_background()` cannot be used after `with_run_frame_tick()`"
         );
         self.background_driver = Some(Arc::new(move |conn: &C| {
@@ -217,7 +222,7 @@ impl<
                 .expect("No module name set. Use with_module_name()"),
             uri: self.uri.clone().expect("No uri set. Use with_uri()"),
             token: self.token.clone(),
-            frame_tick: self.frame_tick,
+            frame_tick: self.frame_tick_driver,
             background_driver: self.background_driver.clone(),
             compression: self.compression.unwrap_or_default(),
             table_registrar: self.table_registrar.clone(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -56,31 +56,34 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     StdbPlugin<C, M>
 {
     /// Sets the function used to drive the connection from the Bevy schedule.
-    pub fn with_frame_tick(mut self, frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>) -> Self {
+    pub fn with_run_frame_tick(
+        mut self,
+        frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>,
+    ) -> Self {
         assert!(
             self.frame_tick.is_none(),
-            "`with_frame_tick()` may only be called once"
+            "`with_run_frame_tick()` may only be called once"
         );
         assert!(
             self.background_driver.is_none(),
-            "`with_frame_tick()` cannot be used after `with_background()`"
+            "`with_run_frame_tick()` cannot be used after `with_run_background()`"
         );
         self.frame_tick = Some(frame_tick);
         self
     }
 
     /// Sets the function used to drive the connection in the background.
-    pub fn with_background<R>(mut self, background_driver: fn(&C) -> R) -> Self
+    pub fn with_run_background<R>(mut self, background_driver: fn(&C) -> R) -> Self
     where
         R: 'static,
     {
         assert!(
             self.background_driver.is_none(),
-            "`with_background()` may only be called once"
+            "`with_run_background()` may only be called once"
         );
         assert!(
             self.frame_tick.is_none(),
-            "`with_background()` cannot be used after `with_frame_tick()`"
+            "`with_run_background()` cannot be used after `with_run_frame_tick()`"
         );
         self.background_driver = Some(Arc::new(move |conn: &C| {
             let _ = background_driver(conn);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     channel_bridge::ChannelBridgePlugin,
-    connection::StdbConnectionPlugin,
+    connection::{ConnectionDriver, StdbConnectionPlugin},
     reconnect::{ReconnectPlugin, StdbReconnectOptions},
     subscription::{StdbSubscriptions, SubscriptionsPlugin},
     table::{TableRegistrar, TableRegistrarCallback},
@@ -30,9 +30,8 @@ pub struct StdbPlugin<
     token: Option<String>,
     compression: Option<Compression>,
 
-    // Options for how to process events from the websocket
-    frame_tick_driver: Option<fn(&C) -> spacetimedb_sdk::Result<()>>,
-    background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
+    // Option for how to process events from the websocket
+    driver: Option<ConnectionDriver<C>>,
 
     // Custom options for reconnect and safely storing sub/table information
     reconnect_options: Option<StdbReconnectOptions>,
@@ -48,8 +47,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             module_name: None,
             uri: None,
             token: None,
-            frame_tick_driver: None,
-            background_driver: None,
+            driver: None,
             compression: None,
             reconnect_options: None,
             subscriptions_initializer: None,
@@ -67,14 +65,10 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>,
     ) -> Self {
         debug_assert!(
-            self.frame_tick_driver.is_none(),
+            self.driver.is_none(),
             "`with_run_frame_tick()` may only be called once"
         );
-        assert!(
-            self.background_driver.is_none(),
-            "`with_run_frame_tick()` cannot be used after `with_run_background()`"
-        );
-        self.frame_tick_driver = Some(frame_tick);
+        self.driver = Some(ConnectionDriver::FrameTick(frame_tick));
         self
     }
 
@@ -85,16 +79,12 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         R: 'static,
     {
         debug_assert!(
-            self.background_driver.is_none(),
+            self.driver.is_none(),
             "`with_run_background()` may only be called once"
         );
-        assert!(
-            self.frame_tick_driver.is_none(),
-            "`with_run_background()` cannot be used after `with_run_frame_tick()`"
-        );
-        self.background_driver = Some(Arc::new(move |conn: &C| {
+        self.driver = Some(ConnectionDriver::Background(Arc::new(move |conn: &C| {
             let _ = background_driver(conn);
-        }));
+        })));
 
         self
     }
@@ -237,8 +227,7 @@ impl<
                 .expect("No module name set. Use with_module_name()"),
             uri: self.uri.clone().expect("No uri set. Use with_uri()"),
             token: self.token.clone(),
-            frame_tick: self.frame_tick_driver,
-            background_driver: self.background_driver.clone(),
+            driver: self.driver.clone(),
             compression: self.compression.unwrap_or_default(),
             table_registrar: self.table_registrar.clone(),
         });

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -60,8 +60,10 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     StdbPlugin<C, M>
 {
     /// Sets the function used to drive the connection from the Bevy schedule.
+    ///
+    /// Exactly one connection driver must be configured for the plugin.
     pub fn with_frame_driver(mut self, frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>) -> Self {
-        debug_assert!(
+        assert!(
             self.driver.is_none(),
             "`with_frame_driver()` may only be called once"
         );
@@ -70,12 +72,13 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     }
 
     /// Sets the function used to drive the connection in the background.
-    /// `run_threaded` or `run_background_task` depending on the build target of the consumer.
+    ///
+    /// Exactly one connection driver must be configured for the plugin.
     pub fn with_background_driver<R>(mut self, background_driver: fn(&C) -> R) -> Self
     where
         R: 'static,
     {
-        debug_assert!(
+        assert!(
             self.driver.is_none(),
             "`with_background_driver()` may only be called once"
         );
@@ -88,7 +91,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Sets the remote module name.
     pub fn with_module_name(mut self, name: impl Into<String>) -> Self {
-        debug_assert!(
+        assert!(
             self.module_name.is_none(),
             "`with_module_name()` may only be called once"
         );
@@ -99,7 +102,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Sets the SpacetimeDB host URI.
     pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
-        debug_assert!(self.uri.is_none(), "`with_uri()` may only be called once");
+        assert!(self.uri.is_none(), "`with_uri()` may only be called once");
         self.uri = Some(uri.into());
 
         self
@@ -107,7 +110,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Sets the authentication token.
     pub fn with_token(mut self, token: impl Into<String>) -> Self {
-        debug_assert!(
+        assert!(
             self.token.is_none(),
             "`with_token()` may only be called once"
         );
@@ -118,7 +121,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Sets the connection compression mode.
     pub fn with_compression(mut self, compression: Compression) -> Self {
-        debug_assert!(
+        assert!(
             self.compression.is_none(),
             "`with_compression()` may only be called once"
         );
@@ -145,7 +148,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         + Sync
         + 'static,
     ) -> Self {
-        debug_assert!(
+        assert!(
             self.table_registrar.is_none(),
             "`with_tables()` may only be called once"
         );
@@ -168,7 +171,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             + Sync
             + 'static,
     {
-        debug_assert!(
+        assert!(
             self.subscriptions_initializer.is_none(),
             "`with_subscriptions()` may only be called once"
         );
@@ -187,7 +190,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Enables automatic reconnects with the given options.
     pub fn with_reconnect(mut self, reconnect_config: StdbReconnectOptions) -> Self {
-        debug_assert!(
+        assert!(
             self.reconnect_options.is_none(),
             "`with_reconnect()` may only be called once"
         );
@@ -203,6 +206,13 @@ impl<
 > Plugin for StdbPlugin<C, M>
 {
     /// Installs the configured `bevy_stdb` plugins and resources.
+    ///
+    /// A connection driver must be configured with exactly one of:
+    /// - `with_background_driver()`
+    /// - `with_frame_driver()`
+    ///
+    /// The configured driver determines how the active connection is progressed
+    /// after creation.
     fn build(&self, app: &mut App) {
         if !app.is_plugin_added::<StatesPlugin>() {
             app.add_plugins(StatesPlugin);
@@ -224,7 +234,11 @@ impl<
                 .expect("No module name set. Use with_module_name()"),
             uri: self.uri.clone().expect("No uri set. Use with_uri()"),
             token: self.token.clone(),
-            driver: self.driver.clone(),
+            driver: self.driver.clone().or_else(|| {
+                panic!(
+                    "No connection driver set. Use with_background_driver() or with_frame_driver()"
+                )
+            }),
             compression: self.compression.unwrap_or_default(),
             table_registrar: self.table_registrar.clone(),
         });

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -60,13 +60,10 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     StdbPlugin<C, M>
 {
     /// Sets the function used to drive the connection from the Bevy schedule.
-    pub fn with_run_frame_tick(
-        mut self,
-        frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>,
-    ) -> Self {
+    pub fn with_frame_driver(mut self, frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>) -> Self {
         debug_assert!(
             self.driver.is_none(),
-            "`with_run_frame_tick()` may only be called once"
+            "`with_frame_driver()` may only be called once"
         );
         self.driver = Some(ConnectionDriver::FrameTick(frame_tick));
         self
@@ -74,13 +71,13 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Sets the function used to drive the connection in the background.
     /// `run_threaded` or `run_background_task` depending on the build target of the consumer.
-    pub fn with_run_background<R>(mut self, background_driver: fn(&C) -> R) -> Self
+    pub fn with_background_driver<R>(mut self, background_driver: fn(&C) -> R) -> Self
     where
         R: 'static,
     {
         debug_assert!(
             self.driver.is_none(),
-            "`with_run_background()` may only be called once"
+            "`with_background_driver()` may only be called once"
         );
         self.driver = Some(ConnectionDriver::Background(Arc::new(move |conn: &C| {
             let _ = background_driver(conn);
@@ -176,7 +173,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             "`with_subscriptions()` may only be called once"
         );
 
-        // This is a bit odd but allows us to not make the entire plugin generic over `K`, so that's nice.
+        // Store a type-erased initializer here so StdbPlugin itself does not need to be generic over K.
         let init = Arc::new(init);
         self.subscriptions_initializer = Some(Arc::new(move |app: &mut App| {
             let init = init.clone();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,7 +14,7 @@ use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     Compression, DbContext, SubscriptionHandle,
 };
-use std::{hash::Hash, sync::Arc, thread::JoinHandle};
+use std::{hash::Hash, sync::Arc};
 
 type SubscriptionsInitializer = dyn Fn(&mut App) + Send + Sync;
 
@@ -26,7 +26,8 @@ pub struct StdbPlugin<
     module_name: Option<String>,
     uri: Option<String>,
     token: Option<String>,
-    run_fn: Option<fn(&C) -> JoinHandle<()>>,
+    frame_tick: Option<fn(&C) -> spacetimedb_sdk::Result<()>>,
+    background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
     compression: Option<Compression>,
     reconnect_options: Option<StdbReconnectOptions>,
     subscriptions_initializer: Option<Arc<SubscriptionsInitializer>>,
@@ -41,8 +42,9 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             module_name: None,
             uri: None,
             token: None,
-            run_fn: None,
-            compression: Some(Compression::default()),
+            frame_tick: None,
+            background_driver: None,
+            compression: None,
             reconnect_options: None,
             subscriptions_initializer: None,
             table_registrar: None,
@@ -53,13 +55,36 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<DbConnection = C>>
     StdbPlugin<C, M>
 {
-    /// Sets the function used to drive the connection.
-    pub fn with_run_fn(mut self, run_fn: fn(&C) -> JoinHandle<()>) -> Self {
+    /// Sets the function used to drive the connection from the Bevy schedule.
+    pub fn with_frame_tick(mut self, frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>) -> Self {
         assert!(
-            self.run_fn.is_none(),
-            "`with_run_fn()` may only be called once"
+            self.frame_tick.is_none(),
+            "`with_frame_tick()` may only be called once"
         );
-        self.run_fn = Some(run_fn);
+        assert!(
+            self.background_driver.is_none(),
+            "`with_frame_tick()` cannot be used after `with_background()`"
+        );
+        self.frame_tick = Some(frame_tick);
+        self
+    }
+
+    /// Sets the function used to drive the connection in the background.
+    pub fn with_background<R>(mut self, background_driver: fn(&C) -> R) -> Self
+    where
+        R: 'static,
+    {
+        assert!(
+            self.background_driver.is_none(),
+            "`with_background()` may only be called once"
+        );
+        assert!(
+            self.frame_tick.is_none(),
+            "`with_background()` cannot be used after `with_frame_tick()`"
+        );
+        self.background_driver = Some(Arc::new(move |conn: &C| {
+            let _ = background_driver(conn);
+        }));
         self
     }
 
@@ -189,7 +214,8 @@ impl<
                 .expect("No module name set. Use with_module_name()"),
             uri: self.uri.clone().expect("No uri set. Use with_uri()"),
             token: self.token.clone(),
-            run_fn: self.run_fn.expect("No run function set. Use with_run_fn()"),
+            frame_tick: self.frame_tick,
+            background_driver: self.background_driver.clone(),
             compression: self.compression.unwrap_or_default(),
             table_registrar: self.table_registrar.clone(),
         });

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -10,6 +10,7 @@ use crate::{
     table::{TableRegistrar, TableRegistrarCallback},
 };
 use bevy_app::{App, Plugin};
+use bevy_state::app::StatesPlugin;
 use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     Compression, DbContext, SubscriptionHandle,
@@ -65,7 +66,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         mut self,
         frame_tick: fn(&C) -> spacetimedb_sdk::Result<()>,
     ) -> Self {
-        assert!(
+        debug_assert!(
             self.frame_tick_driver.is_none(),
             "`with_run_frame_tick()` may only be called once"
         );
@@ -78,11 +79,12 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     }
 
     /// Sets the function used to drive the connection in the background.
+    /// `run_threaded` or `run_background_task` depending on the build target of the consumer.
     pub fn with_run_background<R>(mut self, background_driver: fn(&C) -> R) -> Self
     where
         R: 'static,
     {
-        assert!(
+        debug_assert!(
             self.background_driver.is_none(),
             "`with_run_background()` may only be called once"
         );
@@ -93,43 +95,48 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         self.background_driver = Some(Arc::new(move |conn: &C| {
             let _ = background_driver(conn);
         }));
+
         self
     }
 
     /// Sets the remote module name.
     pub fn with_module_name(mut self, name: impl Into<String>) -> Self {
-        assert!(
+        debug_assert!(
             self.module_name.is_none(),
             "`with_module_name()` may only be called once"
         );
         self.module_name = Some(name.into());
+
         self
     }
 
     /// Sets the SpacetimeDB host URI.
     pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
-        assert!(self.uri.is_none(), "`with_uri()` may only be called once");
+        debug_assert!(self.uri.is_none(), "`with_uri()` may only be called once");
         self.uri = Some(uri.into());
+
         self
     }
 
     /// Sets the authentication token.
     pub fn with_token(mut self, token: impl Into<String>) -> Self {
-        assert!(
+        debug_assert!(
             self.token.is_none(),
             "`with_token()` may only be called once"
         );
         self.token = Some(token.into());
+
         self
     }
 
     /// Sets the connection compression mode.
     pub fn with_compression(mut self, compression: Compression) -> Self {
-        assert!(
+        debug_assert!(
             self.compression.is_none(),
             "`with_compression()` may only be called once"
         );
         self.compression = Some(compression);
+
         self
     }
 
@@ -151,11 +158,12 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         + Sync
         + 'static,
     ) -> Self {
-        assert!(
+        debug_assert!(
             self.table_registrar.is_none(),
             "`with_tables()` may only be called once"
         );
         self.table_registrar = Some(Arc::new(register));
+
         self
     }
 
@@ -173,10 +181,12 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             + Sync
             + 'static,
     {
-        assert!(
+        debug_assert!(
             self.subscriptions_initializer.is_none(),
             "`with_subscriptions()` may only be called once"
         );
+
+        // This is a bit odd but allows us to not make the entire plugin generic over `K`, so that's nice.
         let init = Arc::new(init);
         self.subscriptions_initializer = Some(Arc::new(move |app: &mut App| {
             let init = init.clone();
@@ -184,16 +194,18 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
                 init(subs);
             }));
         }));
+
         self
     }
 
     /// Enables automatic reconnects with the given options.
     pub fn with_reconnect(mut self, reconnect_config: StdbReconnectOptions) -> Self {
-        assert!(
+        debug_assert!(
             self.reconnect_options.is_none(),
             "`with_reconnect()` may only be called once"
         );
         self.reconnect_options = Some(reconnect_config);
+
         self
     }
 }
@@ -205,6 +217,9 @@ impl<
 {
     /// Installs the configured `bevy_stdb` plugins and resources.
     fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<StatesPlugin>() {
+            app.add_plugins(StatesPlugin);
+        }
         app.add_plugins(ChannelBridgePlugin);
 
         if let Some(reconnect_options) = self.reconnect_options.clone() {

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -29,6 +29,12 @@ use std::{sync::Arc, time::Duration};
 
 type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
 
+/// Browser-only receiver for an in-flight reconnect attempt.
+///
+/// The browser reconnect path builds the replacement connection asynchronously
+/// and sends the result back through this resource so runtime systems can
+/// finalize success or failure on the Bevy world thread.
+
 #[cfg(feature = "browser")]
 #[derive(Resource)]
 pub(crate) struct PendingReconnectReceiver<C: DbContext + Send + Sync + 'static> {

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -11,7 +11,9 @@
 //! - `Reconnecting` while retry attempts are pending
 //! - `Exhausted` when retry attempts have been exhausted
 
-use crate::connection::{StdbConnection, StdbConnectionConfig, StdbConnectionState};
+use crate::connection::{
+    ConnectionDriver, StdbConnection, StdbConnectionConfig, StdbConnectionState,
+};
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::prelude::{IntoScheduleConfigs, Res, ResMut, Resource, World};
 use bevy_state::prelude::{NextState, OnEnter, in_state};
@@ -27,7 +29,7 @@ use std::sync::{
 };
 use std::{sync::Arc, time::Duration};
 
-type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
+type ReconnectAttempt<C> = Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>;
 
 /// Browser-only receiver for an in-flight reconnect attempt.
 ///
@@ -183,7 +185,7 @@ where
     }
 
     match try_reconnect::<C, M>(world) {
-        Ok((conn, background_driver)) => on_reconnect_success(world, conn, background_driver),
+        Ok((conn, driver)) => on_reconnect_success(world, conn, driver),
         Err(_) => on_reconnect_failure(world),
     }
 }
@@ -211,7 +213,7 @@ where
 
     wasm_bindgen_futures::spawn_local(async move {
         let result = match config.build_connection().await {
-            Ok(conn) => Ok((conn, config.background_driver.clone())),
+            Ok(conn) => Ok((conn, config.driver.clone())),
             Err(_) => Err(()),
         };
         let _ = tx.send(result);
@@ -230,9 +232,9 @@ where
         .get_resource::<StdbConnectionConfig<C, M>>()
         .expect("StdbConnectionConfig should exist during reconnect");
 
-    let background_driver = config.background_driver.clone();
+    let driver = config.driver.clone();
     match config.build_connection() {
-        Ok(conn) => Ok((conn, background_driver)),
+        Ok(conn) => Ok((conn, driver)),
         Err(_) => Err(()),
     }
 }
@@ -255,17 +257,14 @@ fn ready_to_retry(world: &mut World) -> bool {
     timer.is_finished()
 }
 
-fn on_reconnect_success<C>(
-    world: &mut World,
-    conn: Arc<C>,
-    background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
-) where
+fn on_reconnect_success<C>(world: &mut World, conn: Arc<C>, driver: Option<ConnectionDriver<C>>)
+where
     C: DbContext + Send + Sync + 'static,
 {
     #[cfg(feature = "browser")]
     world.remove_resource::<PendingReconnectReceiver<C>>();
 
-    if let Some(background_driver) = background_driver {
+    if let Some(ConnectionDriver::Background(background_driver)) = driver {
         background_driver(conn.as_ref());
     }
     world.insert_resource(StdbConnection::new(conn));
@@ -306,7 +305,7 @@ where
     };
 
     match result {
-        Ok((conn, background_driver)) => on_reconnect_success(world, conn, background_driver),
+        Ok((conn, driver)) => on_reconnect_success(world, conn, driver),
         Err(_) => {
             world.remove_resource::<PendingReconnectReceiver<C>>();
             on_reconnect_failure(world);

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -20,9 +20,9 @@ use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     DbContext,
 };
-use std::{sync::Arc, thread::JoinHandle, time::Duration};
+use std::{sync::Arc, time::Duration};
 
-type ReconnectAttempt<C> = Result<(Arc<C>, fn(&C) -> JoinHandle<()>), ()>;
+type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
 
 /// Reconnect options for a SpacetimeDB connection.
 #[derive(Clone, Debug)]
@@ -161,7 +161,7 @@ where
     }
 
     match try_reconnect::<C, M>(world) {
-        Ok((conn, run_fn)) => on_reconnect_success(world, conn, run_fn),
+        Ok((conn, background_driver)) => on_reconnect_success(world, conn, background_driver),
         Err(_) => on_reconnect_failure(world),
     }
 }
@@ -193,18 +193,23 @@ where
         .get_resource::<StdbConnectionConfig<C, M>>()
         .expect("StdbConnectionConfig should exist during reconnect");
 
-    let run_fn = config.run_fn;
+    let background_driver = config.background_driver.clone();
     match config.build_connection() {
-        Ok(conn) => Ok((conn, run_fn)),
+        Ok(conn) => Ok((conn, background_driver)),
         Err(_) => Err(()),
     }
 }
 
-fn on_reconnect_success<C>(world: &mut World, conn: Arc<C>, run_fn: fn(&C) -> JoinHandle<()>)
-where
+fn on_reconnect_success<C>(
+    world: &mut World,
+    conn: Arc<C>,
+    background_driver: Option<Arc<dyn Fn(&C) + Send + Sync>>,
+) where
     C: DbContext + Send + Sync + 'static,
 {
-    run_fn(conn.as_ref());
+    if let Some(background_driver) = background_driver {
+        background_driver(conn.as_ref());
+    }
     world.insert_resource(StdbConnection::new(conn));
 
     {

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -20,18 +20,13 @@ use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     DbContext,
 };
-use std::{sync::Arc, time::Duration};
-
 #[cfg(feature = "browser")]
 use std::sync::{
     Mutex,
-    mpsc::{Receiver, channel},
+    mpsc::{Receiver, TryRecvError, channel},
 };
+use std::{sync::Arc, time::Duration};
 
-#[cfg(feature = "browser")]
-type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
-
-#[cfg(not(feature = "browser"))]
 type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
 
 #[cfg(feature = "browser")]
@@ -219,6 +214,23 @@ where
     world.insert_resource(PendingReconnectReceiver::<C> { rx: Mutex::new(rx) });
 }
 
+#[cfg(not(feature = "browser"))]
+fn try_reconnect<C, M>(world: &mut World) -> ReconnectAttempt<C>
+where
+    C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
+    M: SpacetimeModule<DbConnection = C> + 'static,
+{
+    let config = world
+        .get_resource::<StdbConnectionConfig<C, M>>()
+        .expect("StdbConnectionConfig should exist during reconnect");
+
+    let background_driver = config.background_driver.clone();
+    match config.build_connection() {
+        Ok(conn) => Ok((conn, background_driver)),
+        Err(_) => Err(()),
+    }
+}
+
 fn ready_to_retry(world: &mut World) -> bool {
     let delta = world
         .get_resource::<Time>()
@@ -235,23 +247,6 @@ fn ready_to_retry(world: &mut World) -> bool {
 
     timer.tick(delta);
     timer.is_finished()
-}
-
-#[cfg(not(feature = "browser"))]
-fn try_reconnect<C, M>(world: &mut World) -> ReconnectAttempt<C>
-where
-    C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
-    M: SpacetimeModule<DbConnection = C> + 'static,
-{
-    let config = world
-        .get_resource::<StdbConnectionConfig<C, M>>()
-        .expect("StdbConnectionConfig should exist during reconnect");
-
-    let background_driver = config.background_driver.clone();
-    match config.build_connection() {
-        Ok(conn) => Ok((conn, background_driver)),
-        Err(_) => Err(()),
-    }
 }
 
 fn on_reconnect_success<C>(
@@ -293,8 +288,8 @@ where
 
         match rx.try_recv() {
             Ok(result) => Some(result),
-            Err(std::sync::mpsc::TryRecvError::Empty) => None,
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => {
                 panic!("pending browser reconnect task disconnected before returning a result")
             }
         }

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -22,7 +22,23 @@ use spacetimedb_sdk::{
 };
 use std::{sync::Arc, time::Duration};
 
+#[cfg(feature = "browser")]
+use std::sync::{
+    Mutex,
+    mpsc::{Receiver, channel},
+};
+
+#[cfg(feature = "browser")]
 type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
+
+#[cfg(not(feature = "browser"))]
+type ReconnectAttempt<C> = Result<(Arc<C>, Option<Arc<dyn Fn(&C) + Send + Sync>>), ()>;
+
+#[cfg(feature = "browser")]
+#[derive(Resource)]
+pub(crate) struct PendingReconnectReceiver<C: DbContext + Send + Sync + 'static> {
+    pub rx: Mutex<Receiver<ReconnectAttempt<C>>>,
+}
 
 /// Reconnect options for a SpacetimeDB connection.
 #[derive(Clone, Debug)]
@@ -134,7 +150,11 @@ impl<
 
         app.add_systems(
             PreUpdate,
-            tick_reconnect_timer::<C, M>.run_if(in_state(StdbConnectionState::Reconnecting)),
+            (
+                tick_reconnect_timer::<C, M>.run_if(in_state(StdbConnectionState::Reconnecting)),
+                #[cfg(feature = "browser")]
+                finalize_pending_reconnect::<C>.run_if(in_state(StdbConnectionState::Reconnecting)),
+            ),
         );
     }
 }
@@ -151,6 +171,7 @@ fn begin_reconnect_on_disconnect(
     next_state.set(StdbConnectionState::Reconnecting);
 }
 
+#[cfg(not(feature = "browser"))]
 fn tick_reconnect_timer<C, M>(world: &mut World)
 where
     C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
@@ -164,6 +185,38 @@ where
         Ok((conn, background_driver)) => on_reconnect_success(world, conn, background_driver),
         Err(_) => on_reconnect_failure(world),
     }
+}
+
+#[cfg(feature = "browser")]
+fn tick_reconnect_timer<C, M>(world: &mut World)
+where
+    C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
+    M: SpacetimeModule<DbConnection = C> + 'static,
+{
+    if !ready_to_retry(world) {
+        return;
+    }
+
+    if world.contains_resource::<PendingReconnectReceiver<C>>() {
+        return;
+    }
+
+    let config = world
+        .get_resource::<StdbConnectionConfig<C, M>>()
+        .expect("StdbConnectionConfig should exist during reconnect")
+        .clone();
+
+    let (tx, rx) = channel();
+
+    wasm_bindgen_futures::spawn_local(async move {
+        let result = match config.build_connection().await {
+            Ok(conn) => Ok((conn, config.background_driver.clone())),
+            Err(_) => Err(()),
+        };
+        let _ = tx.send(result);
+    });
+
+    world.insert_resource(PendingReconnectReceiver::<C> { rx: Mutex::new(rx) });
 }
 
 fn ready_to_retry(world: &mut World) -> bool {
@@ -184,6 +237,7 @@ fn ready_to_retry(world: &mut World) -> bool {
     timer.is_finished()
 }
 
+#[cfg(not(feature = "browser"))]
 fn try_reconnect<C, M>(world: &mut World) -> ReconnectAttempt<C>
 where
     C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
@@ -207,6 +261,9 @@ fn on_reconnect_success<C>(
 ) where
     C: DbContext + Send + Sync + 'static,
 {
+    #[cfg(feature = "browser")]
+    world.remove_resource::<PendingReconnectReceiver<C>>();
+
     if let Some(background_driver) = background_driver {
         background_driver(conn.as_ref());
     }
@@ -219,6 +276,40 @@ fn on_reconnect_success<C>(
         reconnect.attempts = 0;
         reconnect.current_delay = Duration::ZERO;
         reconnect.timer = None;
+    }
+}
+
+#[cfg(feature = "browser")]
+fn finalize_pending_reconnect<C>(world: &mut World)
+where
+    C: DbContext + Send + Sync + 'static,
+{
+    let result = {
+        let Some(receiver) = world.get_resource::<PendingReconnectReceiver<C>>() else {
+            return;
+        };
+
+        let rx = receiver.rx.lock().unwrap_or_else(|e| e.into_inner());
+
+        match rx.try_recv() {
+            Ok(result) => Some(result),
+            Err(std::sync::mpsc::TryRecvError::Empty) => None,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                panic!("pending browser reconnect task disconnected before returning a result")
+            }
+        }
+    };
+
+    let Some(result) = result else {
+        return;
+    };
+
+    match result {
+        Ok((conn, background_driver)) => on_reconnect_success(world, conn, background_driver),
+        Err(_) => {
+            world.remove_resource::<PendingReconnectReceiver<C>>();
+            on_reconnect_failure(world);
+        }
     }
 }
 

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -29,16 +29,18 @@ use std::sync::{
 };
 use std::{sync::Arc, time::Duration};
 
+/// Browser-only reconnect result type.
+type ReconnectResult<C> = Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>;
+
 /// Browser-only receiver for an in-flight reconnect attempt.
 ///
 /// The browser reconnect path builds the replacement connection asynchronously
 /// and sends the result back through this resource so runtime systems can
 /// finalize success or failure on the Bevy world thread.
-
 #[cfg(feature = "browser")]
 #[derive(Resource)]
 pub(crate) struct PendingReconnectReceiver<C: DbContext + Send + Sync + 'static> {
-    pub rx: Mutex<Receiver<Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>>>,
+    pub rx: Mutex<Receiver<ReconnectResult<C>>>,
 }
 
 /// Reconnect options for a SpacetimeDB connection.
@@ -221,7 +223,7 @@ where
 }
 
 #[cfg(not(feature = "browser"))]
-fn try_reconnect<C, M>(world: &mut World) -> Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>
+fn try_reconnect<C, M>(world: &mut World) -> ReconnectResult<C>
 where
     C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
     M: SpacetimeModule<DbConnection = C> + 'static,

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -29,8 +29,6 @@ use std::sync::{
 };
 use std::{sync::Arc, time::Duration};
 
-type ReconnectAttempt<C> = Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>;
-
 /// Browser-only receiver for an in-flight reconnect attempt.
 ///
 /// The browser reconnect path builds the replacement connection asynchronously
@@ -40,7 +38,7 @@ type ReconnectAttempt<C> = Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>;
 #[cfg(feature = "browser")]
 #[derive(Resource)]
 pub(crate) struct PendingReconnectReceiver<C: DbContext + Send + Sync + 'static> {
-    pub rx: Mutex<Receiver<ReconnectAttempt<C>>>,
+    pub rx: Mutex<Receiver<Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>>>,
 }
 
 /// Reconnect options for a SpacetimeDB connection.
@@ -119,7 +117,7 @@ where
     C: DbConnection<Module = M> + DbContext + Send + Sync,
     M: SpacetimeModule<DbConnection = C>,
 {
-    config: ReconnectConfig,
+    reconnect_options: StdbReconnectOptions,
     _marker: std::marker::PhantomData<(C, M)>,
 }
 
@@ -129,9 +127,9 @@ where
     M: SpacetimeModule<DbConnection = C>,
 {
     /// Creates a reconnect plugin from the given options.
-    pub fn new(options: StdbReconnectOptions) -> Self {
+    pub fn new(reconnect_options: StdbReconnectOptions) -> Self {
         Self {
-            config: options.into(),
+            reconnect_options,
             _marker: std::marker::PhantomData,
         }
     }
@@ -143,7 +141,7 @@ impl<
 > Plugin for ReconnectPlugin<C, M>
 {
     fn build(&self, app: &mut App) {
-        app.insert_resource(self.config.clone());
+        app.insert_resource(ReconnectConfig::from(self.reconnect_options.clone()));
         app.init_resource::<ReconnectState>();
 
         app.add_systems(
@@ -223,7 +221,7 @@ where
 }
 
 #[cfg(not(feature = "browser"))]
-fn try_reconnect<C, M>(world: &mut World) -> ReconnectAttempt<C>
+fn try_reconnect<C, M>(world: &mut World) -> Result<(Arc<C>, Option<ConnectionDriver<C>>), ()>
 where
     C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
     M: SpacetimeModule<DbConnection = C> + 'static,
@@ -261,9 +259,6 @@ fn on_reconnect_success<C>(world: &mut World, conn: Arc<C>, driver: Option<Conne
 where
     C: DbContext + Send + Sync + 'static,
 {
-    #[cfg(feature = "browser")]
-    world.remove_resource::<PendingReconnectReceiver<C>>();
-
     if let Some(ConnectionDriver::Background(background_driver)) = driver {
         background_driver(conn.as_ref());
     }
@@ -294,9 +289,9 @@ where
         match rx.try_recv() {
             Ok(result) => Some(result),
             Err(TryRecvError::Empty) => None,
-            Err(TryRecvError::Disconnected) => {
-                panic!("pending browser reconnect task disconnected before returning a result")
-            }
+            // The receiver is per reconnect attempt.
+            // If its sender drops before sending a result, treat that attempt as a normal reconnect failure.
+            Err(TryRecvError::Disconnected) => Some(Err(())),
         }
     };
 
@@ -304,12 +299,10 @@ where
         return;
     };
 
+    world.remove_resource::<PendingReconnectReceiver<C>>();
     match result {
         Ok((conn, driver)) => on_reconnect_success(world, conn, driver),
-        Err(_) => {
-            world.remove_resource::<PendingReconnectReceiver<C>>();
-            on_reconnect_failure(world);
-        }
+        Err(_) => on_reconnect_failure(world),
     }
 }
 


### PR DESCRIPTION
This PR refactors how SpacetimeDB connections are driven, adding support for browser/wasm target.

### Highlights

- Replaces the old single `run_fn` approach with explicit driver configuration:
  - `with_run_background(...)`
  - `with_run_frame_tick(...)`
- Adds an internal `ConnectionDriver` abstraction to unify mutually exclusive driver modes.
- Adds browser-specific async connection startup behind a new `browser` feature using `wasm-bindgen-futures`.
- Updates reconnect and startup flow to work correctly across native and browser targets.
- Updates README examples for the new flow

### Why

This makes connection startup and driving clearer, more flexible, and easier to use across native and wasm builds, while keeping the plugin lifecycle aligned with Bevy’s startup model.


**Native + Web working**
[reconnect_both_web_native.webm](https://github.com/user-attachments/assets/1f20ade5-f226-4b7a-8d37-c8e64fef5ee0)
