### PR TITLE
feat: build the table from events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_state",
  "bevy_time",
+ "crossbeam-channel",
  "spacetimedb-sdk",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_stdb"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bevy_state = "0.18"
 bevy_time = "0.18"
 spacetimedb-sdk = "2.1"
 wasm-bindgen-futures = { version = "0.4", optional = true }
-
+crossbeam-channel = "0.5"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_stdb"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.93"
 description = "A Bevy-native integration for SpacetimeDB with table messages, subscriptions, and reconnect support."

--- a/src/channel_bridge.rs
+++ b/src/channel_bridge.rs
@@ -52,15 +52,20 @@ impl Plugin for ChannelBridgePlugin {
 
 /// Registers a channel for message type `T`.
 ///
-/// Returns an existing sender if the channel has already been registered.
-///
 /// # Panics
 ///
-/// Panics if [`ChannelRegistry`] has not been initialized.
-pub(crate) fn register_channel<T: Message>(app: &mut App) -> Sender<T> {
-    if let Some(sender) = channel_sender::<T>(app.world()) {
-        return sender;
-    }
+/// Panics if [`ChannelRegistry`] has not been initialized or if the
+/// channel for `T` has already been registered.
+pub(crate) fn register_channel<T: Message>(app: &mut App) {
+    assert!(
+        !app.world()
+            .resource::<ChannelRegistry>()
+            .channels
+            .iter()
+            .any(|entry| entry.type_id == TypeId::of::<T>()),
+        "attempted to register channel for message type `{}` more than once",
+        std::any::type_name::<T>(),
+    );
 
     let (tx, rx) = channel::<T>();
     let tx_for_lookup = tx.clone();
@@ -91,19 +96,40 @@ pub(crate) fn register_channel<T: Message>(app: &mut App) -> Sender<T> {
             }),
             clone_sender: Box::new(move || Box::new(tx_for_lookup.clone())),
         });
-
-    tx
 }
 
-/// Returns the registered `Sender<T>`, if one exists.
-pub(crate) fn channel_sender<T: Message>(world: &World) -> Option<Sender<T>> {
-    let registry = world.get_resource::<ChannelRegistry>()?;
+/// Returns the registered `Sender<T>`.
+///
+/// # Panics
+///
+/// Panics if [`ChannelRegistry`] has not been initialized, if the
+/// channel for `T` has not been registered, or if the stored sender
+/// has an unexpected concrete type.
+pub(crate) fn channel_sender<T: Message>(world: &World) -> Sender<T> {
+    let registry = world
+        .get_resource::<ChannelRegistry>()
+        .expect("channel registry should be initialized before accessing channel senders");
 
     let entry = registry
         .channels
         .iter()
-        .find(|entry| entry.type_id == TypeId::of::<T>())?;
+        .find(|entry| entry.type_id == TypeId::of::<T>())
+        .unwrap_or_else(|| {
+            panic!(
+                "channel for message type `{}` should be registered before accessing its sender",
+                std::any::type_name::<T>(),
+            )
+        });
 
     let boxed = (entry.clone_sender)();
-    boxed.downcast::<Sender<T>>().ok().map(|sender| *sender)
+    boxed
+        .downcast::<Sender<T>>()
+        .unwrap_or_else(|_| {
+            panic!(
+                "stored sender for message type `{}` had an unexpected concrete type",
+                std::any::type_name::<T>(),
+            )
+        })
+        .as_ref()
+        .clone()
 }

--- a/src/channel_bridge.rs
+++ b/src/channel_bridge.rs
@@ -3,30 +3,21 @@
 //! This module registers per-type channels and forwards queued values into `Messages<T>`.
 
 use bevy_app::{App, Plugin, PreUpdate};
-use bevy_ecs::{
-    message::{Message, Messages},
-    resource::Resource,
-    world::World,
-};
+use bevy_ecs::prelude::{Message, Messages, Mut, Resource, World};
+use crossbeam_channel::{Sender, unbounded};
 use std::{
     any::{Any, TypeId},
-    sync::{
-        Mutex,
-        mpsc::{Sender, channel},
-    },
+    sync::Arc,
 };
-
-/// A type-erased function that drains a channel into `Messages<T>`.
-type DrainFn = Box<dyn Fn(&mut World) + Send + Sync>;
-
-/// A type-erased function that clones a registered `Sender<T>`.
-type CloneSenderFn = Box<dyn Fn() -> Box<dyn Any + Send> + Send + Sync>;
 
 /// Stores the registered message channels.
 struct ChannelEntry {
+    /// The registered message type.
     type_id: TypeId,
-    drain: DrainFn,
-    clone_sender: CloneSenderFn,
+    /// A type-erased function that drains a channel into `Messages<T>`.
+    drain: Box<dyn Fn(&mut World) + Send + Sync>,
+    /// The sender for this message type.
+    sender: Arc<dyn Any + Send + Sync>,
 }
 
 #[derive(Resource, Default)]
@@ -38,22 +29,22 @@ pub(crate) struct ChannelBridgePlugin;
 impl Plugin for ChannelBridgePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ChannelRegistry>();
-
-        // Drain all registered channels once per frame.
-        app.add_systems(PreUpdate, |world: &mut World| {
-            let Some(reg) = world.remove_resource::<ChannelRegistry>() else {
-                return;
-            };
-            reg.channels.iter().for_each(|e| (e.drain)(world));
-            world.insert_resource(reg);
-        });
+        app.add_systems(PreUpdate, drain_channels);
     }
+}
+
+/// Drain all registered channels once per frame.
+fn drain_channels(world: &mut World) {
+    world.resource_scope(|world, registry: Mut<ChannelRegistry>| {
+        for entry in &registry.channels {
+            (entry.drain)(world);
+        }
+    });
 }
 
 /// Registers a channel for message type `T`.
 ///
 /// # Panics
-///
 /// Panics if [`ChannelRegistry`] has not been initialized or if the
 /// channel for `T` has already been registered.
 pub(crate) fn register_channel<T: Message>(app: &mut App) {
@@ -67,10 +58,7 @@ pub(crate) fn register_channel<T: Message>(app: &mut App) {
         std::any::type_name::<T>(),
     );
 
-    let (tx, rx) = channel::<T>();
-    let tx_for_lookup = tx.clone();
-    let rx = Mutex::new(rx);
-
+    let (tx, rx) = unbounded::<T>();
     app.add_message::<T>();
 
     app.world_mut()
@@ -79,22 +67,11 @@ pub(crate) fn register_channel<T: Message>(app: &mut App) {
         .push(ChannelEntry {
             type_id: TypeId::of::<T>(),
             drain: Box::new(move |world: &mut World| {
-                let msgs: Vec<T> = {
-                    let rx = rx.lock().unwrap_or_else(|e| e.into_inner());
-                    rx.try_iter().collect()
-                };
-
-                if msgs.is_empty() {
-                    return;
+                if let Some(mut messages) = world.get_resource_mut::<Messages<T>>() {
+                    messages.write_batch(rx.try_iter());
                 }
-
-                let Some(mut messages) = world.get_resource_mut::<Messages<T>>() else {
-                    return;
-                };
-
-                messages.write_batch(msgs);
             }),
-            clone_sender: Box::new(move || Box::new(tx_for_lookup.clone())),
+            sender: Arc::new(tx.clone()),
         });
 }
 
@@ -117,19 +94,19 @@ pub(crate) fn channel_sender<T: Message>(world: &World) -> Sender<T> {
         .unwrap_or_else(|| {
             panic!(
                 "channel for message type `{}` should be registered before accessing its sender",
-                std::any::type_name::<T>(),
+                std::any::type_name::<T>()
             )
         });
 
-    let boxed = (entry.clone_sender)();
-    boxed
-        .downcast::<Sender<T>>()
-        .unwrap_or_else(|_| {
+    entry
+        .sender
+        .as_ref()
+        .downcast_ref::<Sender<T>>()
+        .unwrap_or_else(|| {
             panic!(
                 "stored sender for message type `{}` had an unexpected concrete type",
                 std::any::type_name::<T>(),
             )
         })
-        .as_ref()
         .clone()
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,13 +20,14 @@ use bevy_state::{
     condition::in_state,
     state::{NextState, OnEnter, States},
 };
+use crossbeam_channel::Sender;
 use spacetimedb_sdk::{
     __codegen::{DbConnection, SpacetimeModule},
     Compression, ConnectionId, DbConnectionBuilder, DbContext, Identity, Result,
 };
 #[cfg(feature = "browser")]
 use std::sync::mpsc::{Receiver, TryRecvError, channel};
-use std::sync::{Arc, Mutex, mpsc::Sender};
+use std::sync::{Arc, Mutex};
 
 /// Internal startup status for the initial SpacetimeDB connection.
 ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,7 +5,7 @@ use crate::{
     alias::{
         ReadStdbConnectedMessage, ReadStdbConnectionErrorMessage, ReadStdbDisconnectedMessage,
     },
-    channel_bridge::register_channel,
+    channel_bridge::{channel_sender, register_channel},
     message::{StdbConnectedMessage, StdbConnectionErrorMessage, StdbDisconnectedMessage},
     table::{TableRegistrar, TableRegistrarCallback},
 };
@@ -272,6 +272,11 @@ impl<
     fn build(&self, app: &mut App) {
         app.init_state::<StdbConnectionState>();
 
+        register_channel::<StdbConnectedMessage>(app);
+        register_channel::<StdbDisconnectedMessage>(app);
+        register_channel::<StdbConnectionErrorMessage>(app);
+
+        let world = app.world();
         let config = StdbConnectionConfig::<C, M> {
             module_name: self.module_name.clone(),
             uri: self.uri.clone(),
@@ -279,9 +284,9 @@ impl<
             driver: self.driver.clone(),
             compression: self.compression,
             table_registrar: self.table_registrar.clone(),
-            connected_tx: register_channel::<StdbConnectedMessage>(app),
-            disconnected_tx: register_channel::<StdbDisconnectedMessage>(app),
-            error_tx: register_channel::<StdbConnectionErrorMessage>(app),
+            connected_tx: channel_sender::<StdbConnectedMessage>(world),
+            disconnected_tx: channel_sender::<StdbDisconnectedMessage>(world),
+            error_tx: channel_sender::<StdbConnectionErrorMessage>(world),
         };
 
         let initial_connection_state = {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     channel_bridge::{channel_sender, register_channel},
     message::{StdbConnectedMessage, StdbConnectionErrorMessage, StdbDisconnectedMessage},
-    table::{TableRegistrar, TableRegistrarCallback},
+    table::{RegistrarMode, TableRegistrar, TableRegistrarCallback},
 };
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::{
@@ -391,7 +391,7 @@ impl<
 
         if let Some(register) = table_registrar {
             let db = conn.db();
-            register(&mut TableRegistrar::new_init(app), db);
+            register(&mut TableRegistrar::new(RegistrarMode::Init(app)), db);
         }
 
         if let Some(ConnectionDriver::Background(background_driver)) = driver {
@@ -437,7 +437,7 @@ fn on_connected_bind<
 
     let db = conn.db();
     if let Some(register) = &config.table_registrar {
-        register(&mut TableRegistrar::new_bind(&*world), db);
+        register(&mut TableRegistrar::new(RegistrarMode::Bind(&*world)), db);
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -131,9 +131,7 @@ where
 
     /// Queues all stored subscriptions to be applied again.
     pub(crate) fn queue_all(&mut self) {
-        for key in self.sql_by_key.keys().cloned() {
-            self.queued_keys.insert(key);
-        }
+        self.queued_keys.extend(self.sql_by_key.keys().cloned());
     }
 
     /// Applies queued subscriptions to the active connection.
@@ -146,16 +144,13 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
-        let keys: Vec<K> = self.queued_keys.drain().collect();
-
+        let keys = std::mem::take(&mut self.queued_keys);
         for key in keys {
-            let Some(sql) = self.sql_by_key.get(&key).cloned() else {
-                continue;
-            };
-
             let _ = self.drop_active_handle(&key);
-            let handle = conn.subscription_builder().subscribe(sql);
-            self.handles.insert(key, handle);
+            if let Some(sql) = self.sql_by_key.get(&key) {
+                let handle = conn.subscription_builder().subscribe(sql.as_str());
+                self.handles.insert(key, handle);
+            }
         }
     }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs,
     system::{Res, ResMut},
 };
-use bevy_state::{condition::in_state, state::OnEnter};
+use bevy_state::state::OnEnter;
 use spacetimedb_sdk::{
     __codegen::{__query_builder::Query, DbConnection, SpacetimeModule, SubscriptionBuilder},
     DbContext, Result as StdbResult, SubscriptionHandle as StdbSubscriptionHandle,
@@ -83,7 +83,10 @@ where
     pub fn unsubscribe(&mut self, key: &K) -> StdbResult<()> {
         self.sql_by_key.remove(key);
         self.queued_keys.remove(key);
-        self.drop_active_handle(key)
+        if let Some(handle) = self.handles.remove(key) {
+            handle.unsubscribe()?;
+        };
+        Ok(())
     }
 
     /// Unsubscribes all active handles and clears all stored queries.
@@ -146,20 +149,13 @@ where
     {
         let keys = std::mem::take(&mut self.queued_keys);
         for key in keys {
-            let _ = self.drop_active_handle(&key);
             if let Some(sql) = self.sql_by_key.get(&key) {
                 let handle = conn.subscription_builder().subscribe(sql.as_str());
-                self.handles.insert(key, handle);
+                if let Some(old_handle) = self.handles.insert(key, handle) {
+                    let _ = old_handle.unsubscribe();
+                }
             }
         }
-    }
-
-    /// Unsubscribes and removes the active handle for `key` without removing its stored query.
-    fn drop_active_handle(&mut self, key: &K) -> StdbResult<()> {
-        if let Some(handle) = self.handles.remove(key) {
-            handle.unsubscribe()?;
-        }
-        Ok(())
     }
 }
 
@@ -226,9 +222,21 @@ where
 
         app.add_systems(
             PreUpdate,
-            apply_queued_subscriptions::<K, C, M>.run_if(in_state(StdbConnectionState::Connected)),
+            apply_queued_subscriptions::<K, C, M>.run_if(should_apply_subscriptions::<K, M>),
         );
     }
+}
+
+fn should_apply_subscriptions<K, M>(
+    subs: Res<StdbSubscriptions<K, M>>,
+    state: Res<bevy_state::state::State<StdbConnectionState>>,
+) -> bool
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    M: SpacetimeModule,
+    M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
+{
+    !subs.queued_keys.is_empty() && *state.get() == StdbConnectionState::Connected
 }
 
 /// Re-queues stored subscriptions after a disconnect.

--- a/src/table.rs
+++ b/src/table.rs
@@ -12,8 +12,7 @@ use spacetimedb_sdk::__codegen::DbContext;
 use spacetimedb_sdk::{EventTable, Table, TableWithPrimaryKey};
 use std::{marker::PhantomData, sync::mpsc::Sender};
 
-pub(crate) trait NonEventTable {}
-
+pub trait NonEventTable {}
 impl<T> NonEventTable for T where T: Table + ?Sized {}
 
 pub(crate) type TableRegistrarCallback<C> =
@@ -83,6 +82,44 @@ impl<'a> TableRegistrar<'a> {
         });
     }
 
+    /// Registers a table without a primary key.
+    ///
+    /// Forwards inserts and deletes as [`InsertMessage`] and [`DeleteMessage`].
+    pub fn table_without_pk<TRow, TTable>(&mut self, table: &TTable)
+    where
+        TRow: Send + Sync + Clone + 'static,
+        TTable: Table<Row = TRow>,
+    {
+        self.build(table, |table| {
+            table.insert();
+            table.delete();
+        });
+    }
+
+    /// Registers a view.
+    ///
+    /// This is equivalent to [`TableRegistrar::table_without_pk`].
+    pub fn view<TRow, TTable>(&mut self, table: &TTable)
+    where
+        TRow: Send + Sync + Clone + 'static,
+        TTable: Table<Row = TRow>,
+    {
+        self.table_without_pk(table);
+    }
+
+    /// Registers an event table.
+    ///
+    /// Forwards inserts as [`InsertMessage`].
+    pub fn event_table<TRow, TTable>(&mut self, table: &TTable)
+    where
+        TRow: Send + Sync + Clone + 'static,
+        TTable: Table<Row = TRow> + EventTable,
+    {
+        self.build(table, |table| {
+            table.insert();
+        });
+    }
+
     /// Registers a table using a configurable builder.
     ///
     /// Base bindings available for all tables:
@@ -108,68 +145,6 @@ impl<'a> TableRegistrar<'a> {
         };
 
         build(&mut builder);
-    }
-
-    /// Registers a table without a primary key.
-    ///
-    /// Forwards inserts and deletes as [`InsertMessage`] and [`DeleteMessage`].
-    pub fn table_without_pk<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
-    {
-        self.view_build(table, |table| {
-            table.insert();
-            table.delete();
-        });
-    }
-
-    /// Registers a view.
-    ///
-    /// This is equivalent to [`TableRegistrar::table_without_pk`].
-    pub fn view<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
-    {
-        self.table_without_pk(table);
-    }
-
-    /// Registers a table without a primary key using a configurable builder.
-    pub fn view_build<TRow, TTable>(
-        &mut self,
-        table: &TTable,
-        build: impl for<'r> FnOnce(&mut TableBindingBuilder<'r, 'a, TRow, TTable>),
-    ) where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
-    {
-        self.build(table, build);
-    }
-
-    /// Registers an event table.
-    ///
-    /// Forwards inserts as [`InsertMessage`].
-    pub fn event_table<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow> + EventTable,
-    {
-        self.event_table_build(table, |table| {
-            table.insert();
-        });
-    }
-
-    /// Registers an event table using a configurable builder.
-    pub fn event_table_build<TRow, TTable>(
-        &mut self,
-        table: &TTable,
-        build: impl for<'r> FnOnce(&mut TableBindingBuilder<'r, 'a, TRow, TTable>),
-    ) where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow> + EventTable,
-    {
-        self.build(table, build);
     }
 
     /// Returns the sender for the given message type and TableRegistrar mode.

--- a/src/table.rs
+++ b/src/table.rs
@@ -10,7 +10,11 @@ use bevy_app::App;
 use bevy_ecs::{message::Message, world::World};
 use spacetimedb_sdk::__codegen::DbContext;
 use spacetimedb_sdk::{EventTable, Table, TableWithPrimaryKey};
-use std::sync::mpsc::Sender;
+use std::{marker::PhantomData, sync::mpsc::Sender};
+
+pub(crate) trait NonEventTable {}
+
+impl<T> NonEventTable for T where T: Table + ?Sized {}
 
 pub(crate) type TableRegistrarCallback<C> =
     dyn for<'a, 'db> Fn(&mut TableRegistrar<'a>, &'db <C as DbContext>::DbView) + Send + Sync;
@@ -26,6 +30,25 @@ pub struct TableRegistrar<'a> {
 enum TableRegistrarMode<'a> {
     Init(&'a mut App),
     Bind(&'a World),
+}
+
+/// Builder for configuring which table events should be forwarded.
+///
+/// Base methods available for all tables:
+/// - [`TableBindingBuilder::insert`]
+/// - [`TableBindingBuilder::delete`]
+///
+/// Additional methods available only for tables with a primary key:
+/// - [`PkTableBindingBuilder::update`]
+/// - [`PkTableBindingBuilder::insert_update`]
+pub struct TableBindingBuilder<'r, 't, TRow, TTable>
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow>,
+{
+    registrar: &'r mut TableRegistrar<'t>,
+    table: &'r TTable,
+    _row: PhantomData<TRow>,
 }
 
 impl<'a> TableRegistrar<'a> {
@@ -52,20 +75,39 @@ impl<'a> TableRegistrar<'a> {
         TRow: Send + Sync + Clone + 'static,
         TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                let _ = register_channel::<InsertMessage<TRow>>(app);
-                let _ = register_channel::<DeleteMessage<TRow>>(app);
-                let _ = register_channel::<UpdateMessage<TRow>>(app);
-                let _ = register_channel::<InsertUpdateMessage<TRow>>(app);
-            }
-            TableRegistrarMode::Bind(_) => {
-                self.bind_insert(table);
-                self.bind_delete(table);
-                self.bind_update(table);
-                self.bind_insert_update(table);
-            }
-        }
+        self.build(table, |table| {
+            table.insert();
+            table.delete();
+            table.update();
+            table.insert_update();
+        });
+    }
+
+    /// Registers a table using a configurable builder.
+    ///
+    /// Base bindings available for all tables:
+    /// - [`TableBindingBuilder::insert`]
+    ///
+    /// Additional bindings become available when the table satisfies the
+    /// required trait bounds:
+    /// - [`TableBindingBuilder::delete`] for non-event tables
+    /// - [`TableBindingBuilder::update`] for tables with a primary key
+    /// - [`TableBindingBuilder::insert_update`] for tables with a primary key
+    pub fn build<TRow, TTable>(
+        &mut self,
+        table: &TTable,
+        build: impl for<'r> FnOnce(&mut TableBindingBuilder<'r, 'a, TRow, TTable>),
+    ) where
+        TRow: Send + Sync + Clone + 'static,
+        TTable: Table<Row = TRow>,
+    {
+        let mut builder = TableBindingBuilder {
+            registrar: self,
+            table,
+            _row: PhantomData,
+        };
+
+        build(&mut builder);
     }
 
     /// Registers a table without a primary key.
@@ -76,16 +118,10 @@ impl<'a> TableRegistrar<'a> {
         TRow: Send + Sync + Clone + 'static,
         TTable: Table<Row = TRow>,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                let _ = register_channel::<InsertMessage<TRow>>(app);
-                let _ = register_channel::<DeleteMessage<TRow>>(app);
-            }
-            TableRegistrarMode::Bind(_) => {
-                self.bind_insert(table);
-                self.bind_delete(table);
-            }
-        }
+        self.view_build(table, |table| {
+            table.insert();
+            table.delete();
+        });
     }
 
     /// Registers a view.
@@ -99,6 +135,18 @@ impl<'a> TableRegistrar<'a> {
         self.table_without_pk(table);
     }
 
+    /// Registers a table without a primary key using a configurable builder.
+    pub fn view_build<TRow, TTable>(
+        &mut self,
+        table: &TTable,
+        build: impl for<'r> FnOnce(&mut TableBindingBuilder<'r, 'a, TRow, TTable>),
+    ) where
+        TRow: Send + Sync + Clone + 'static,
+        TTable: Table<Row = TRow>,
+    {
+        self.build(table, build);
+    }
+
     /// Registers an event table.
     ///
     /// Forwards inserts as [`InsertMessage`].
@@ -107,14 +155,21 @@ impl<'a> TableRegistrar<'a> {
         TRow: Send + Sync + Clone + 'static,
         TTable: Table<Row = TRow> + EventTable,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                let _ = register_channel::<InsertMessage<TRow>>(app);
-            }
-            TableRegistrarMode::Bind(_) => {
-                self.bind_insert(table);
-            }
-        }
+        self.event_table_build(table, |table| {
+            table.insert();
+        });
+    }
+
+    /// Registers an event table using a configurable builder.
+    pub fn event_table_build<TRow, TTable>(
+        &mut self,
+        table: &TTable,
+        build: impl for<'r> FnOnce(&mut TableBindingBuilder<'r, 'a, TRow, TTable>),
+    ) where
+        TRow: Send + Sync + Clone + 'static,
+        TTable: Table<Row = TRow> + EventTable,
+    {
+        self.build(table, build);
     }
 
     /// Returns the sender for the given message type and TableRegistrar mode.
@@ -123,10 +178,11 @@ impl<'a> TableRegistrar<'a> {
         T: Message,
     {
         match &mut self.mode {
-            TableRegistrarMode::Init(app) => register_channel::<T>(app),
-            TableRegistrarMode::Bind(world) => channel_sender::<T>(world).expect(
-                "message channel should be initialized during plugin finish before runtime binding",
-            ),
+            TableRegistrarMode::Init(app) => {
+                register_channel::<T>(app);
+                channel_sender::<T>(app.world())
+            }
+            TableRegistrarMode::Bind(world) => channel_sender::<T>(world),
         }
     }
 
@@ -191,5 +247,49 @@ impl<'a> TableRegistrar<'a> {
                 new: new.clone(),
             });
         });
+    }
+}
+
+impl<'r, 't, TRow, TTable> TableBindingBuilder<'r, 't, TRow, TTable>
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow>,
+{
+    /// Forwards inserts as [`InsertMessage`].
+    pub fn insert(&mut self) -> &mut Self {
+        self.registrar.bind_insert::<TRow, TTable>(self.table);
+        self
+    }
+}
+
+impl<'r, 't, TRow, TTable> TableBindingBuilder<'r, 't, TRow, TTable>
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow>,
+    TTable: TableWithPrimaryKey<Row = TRow>,
+{
+    /// Forwards updates as [`UpdateMessage`].
+    pub fn update(&mut self) -> &mut Self {
+        self.registrar.bind_update::<TRow, TTable>(self.table);
+        self
+    }
+
+    /// Forwards inserts and updates as [`InsertUpdateMessage`].
+    pub fn insert_update(&mut self) -> &mut Self {
+        self.registrar
+            .bind_insert_update::<TRow, TTable>(self.table);
+        self
+    }
+}
+
+impl<'r, 't, TRow, TTable> TableBindingBuilder<'r, 't, TRow, TTable>
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow> + NonEventTable,
+{
+    /// Forwards deletes as [`DeleteMessage`].
+    pub fn delete(&mut self) -> &mut Self {
+        self.registrar.bind_delete::<TRow, TTable>(self.table);
+        self
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -65,6 +65,14 @@ impl<'a> TableRegistrar<'a> {
         }
     }
 
+    /// Returns the init-phase app.
+    fn expect_init(&mut self) -> &mut App {
+        match &mut self.mode {
+            TableRegistrarMode::Init(app) => app,
+            _ => panic!("table registration is only valid during table init"),
+        }
+    }
+
     /// Registers a table with a primary key.
     ///
     /// Forwards table changes as:
@@ -165,12 +173,7 @@ impl<'a> TableRegistrar<'a> {
     where
         TRow: Send + Sync + Clone + 'static,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                register_channel::<InsertMessage<TRow>>(app);
-            }
-            _ => panic!("insert registration is only valid during table init"),
-        }
+        register_channel::<InsertMessage<TRow>>(self.expect_init());
     }
 
     /// Registers delete forwarding for the given table.
@@ -178,12 +181,7 @@ impl<'a> TableRegistrar<'a> {
     where
         TRow: Send + Sync + Clone + 'static,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                register_channel::<DeleteMessage<TRow>>(app);
-            }
-            _ => panic!("delete registration is only valid during table init"),
-        }
+        register_channel::<DeleteMessage<TRow>>(self.expect_init());
     }
 
     /// Registers update forwarding for the given table.
@@ -191,12 +189,7 @@ impl<'a> TableRegistrar<'a> {
     where
         TRow: Send + Sync + Clone + 'static,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                register_channel::<UpdateMessage<TRow>>(app);
-            }
-            _ => panic!("update registration is only valid during table init"),
-        }
+        register_channel::<UpdateMessage<TRow>>(self.expect_init());
     }
 
     /// Registers insert-or-update forwarding for the given table.
@@ -204,12 +197,7 @@ impl<'a> TableRegistrar<'a> {
     where
         TRow: Send + Sync + Clone + 'static,
     {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                register_channel::<InsertUpdateMessage<TRow>>(app);
-            }
-            _ => panic!("insert_update registration is only valid during table init"),
-        }
+        register_channel::<InsertUpdateMessage<TRow>>(self.expect_init());
     }
 
     /// Binds insert forwarding for the given table.

--- a/src/table.rs
+++ b/src/table.rs
@@ -7,39 +7,39 @@ use crate::{
     message::{DeleteMessage, InsertMessage, InsertUpdateMessage, UpdateMessage},
 };
 use bevy_app::App;
-use bevy_ecs::{message::Message, world::World};
+use bevy_ecs::world::World;
 use spacetimedb_sdk::__codegen::DbContext;
 use spacetimedb_sdk::{EventTable, Table, TableWithPrimaryKey};
-use std::{marker::PhantomData, sync::mpsc::Sender};
-
-pub trait NonEventTable {}
-impl<T> NonEventTable for T where T: Table + ?Sized {}
+use std::marker::PhantomData;
 
 pub(crate) type TableRegistrarCallback<C> =
     dyn for<'a, 'db> Fn(&mut TableRegistrar<'a>, &'db <C as DbContext>::DbView) + Send + Sync;
+
+pub(crate) enum RegistrarMode<'a> {
+    Init(&'a mut App),
+    Bind(&'a World),
+}
+
+pub trait NonEventTable {}
+impl<T> NonEventTable for T where T: Table + ?Sized {}
 
 /// Registers SpacetimeDB table callbacks as Bevy messages.
 ///
 /// Registration runs once to initialize channels and again to bind callbacks
 /// for the active connection.
 pub struct TableRegistrar<'a> {
-    mode: TableRegistrarMode<'a>,
-}
-
-enum TableRegistrarMode<'a> {
-    Init(&'a mut App),
-    Bind(&'a World),
+    mode: RegistrarMode<'a>,
 }
 
 /// Builder for configuring which table events should be forwarded.
 ///
 /// Base methods available for all tables:
 /// - [`TableBindingBuilder::insert`]
-/// - [`TableBindingBuilder::delete`]
 ///
 /// Additional methods available only for tables with a primary key:
 /// - [`TableBindingBuilder::update`]
 /// - [`TableBindingBuilder::insert_update`]
+/// - [`TableBindingBuilder::delete`]
 pub struct TableBindingBuilder<'r, 't, TRow, TTable>
 where
     TRow: Send + Sync + Clone + 'static,
@@ -51,26 +51,9 @@ where
 }
 
 impl<'a> TableRegistrar<'a> {
-    /// Creates a registrar that initializes message channels.
-    pub fn new_init(app: &'a mut App) -> Self {
-        Self {
-            mode: TableRegistrarMode::Init(app),
-        }
-    }
-
-    /// Creates a registrar that binds callbacks for the active connection.
-    pub fn new_bind(world: &'a World) -> Self {
-        Self {
-            mode: TableRegistrarMode::Bind(world),
-        }
-    }
-
-    /// Returns the init-phase app.
-    fn expect_init(&mut self) -> &mut App {
-        match &mut self.mode {
-            TableRegistrarMode::Init(app) => app,
-            _ => panic!("table registration is only valid during table init"),
-        }
+    /// Creates a new [`TableRegistrar`] with the given mode.
+    pub(crate) fn new(mode: RegistrarMode<'a>) -> Self {
+        Self { mode }
     }
 
     /// Registers a table with a primary key.
@@ -146,88 +129,10 @@ impl<'a> TableRegistrar<'a> {
         TRow: Send + Sync + Clone + 'static,
         TTable: Table<Row = TRow>,
     {
-        let mut builder = TableBindingBuilder {
+        build(&mut TableBindingBuilder {
             registrar: self,
             table,
             _row: PhantomData,
-        };
-
-        build(&mut builder);
-    }
-
-    /// Returns the sender for the given message type during runtime binding.
-    fn sender<T>(&mut self) -> Sender<T>
-    where
-        T: Message,
-    {
-        match &mut self.mode {
-            TableRegistrarMode::Init(_) => {
-                panic!("sender lookup is only valid during runtime table binding")
-            }
-            TableRegistrarMode::Bind(world) => channel_sender::<T>(world),
-        }
-    }
-
-    /// Binds insert forwarding for the given table.
-    fn bind_insert<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
-    {
-        let sender = self.sender::<InsertMessage<TRow>>();
-        table.on_insert(move |_ctx, row| {
-            let _ = sender.send(InsertMessage { row: row.clone() });
-        });
-    }
-
-    /// Binds delete forwarding for the given table.
-    fn bind_delete<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
-    {
-        let sender = self.sender::<DeleteMessage<TRow>>();
-        table.on_delete(move |_ctx, row| {
-            let _ = sender.send(DeleteMessage { row: row.clone() });
-        });
-    }
-
-    /// Binds update forwarding for the given table.
-    fn bind_update<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
-    {
-        let sender = self.sender::<UpdateMessage<TRow>>();
-        table.on_update(move |_ctx, old, new| {
-            let _ = sender.send(UpdateMessage {
-                old: old.clone(),
-                new: new.clone(),
-            });
-        });
-    }
-
-    /// Binds insert-or-update forwarding for the given table.
-    fn bind_insert_update<TRow, TTable>(&mut self, table: &TTable)
-    where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
-    {
-        let sender_insert = self.sender::<InsertUpdateMessage<TRow>>();
-        let sender_update = self.sender::<InsertUpdateMessage<TRow>>();
-
-        table.on_insert(move |_ctx, row| {
-            let _ = sender_insert.send(InsertUpdateMessage {
-                old: None,
-                new: row.clone(),
-            });
-        });
-
-        table.on_update(move |_ctx, old, new| {
-            let _ = sender_update.send(InsertUpdateMessage {
-                old: Some(old.clone()),
-                new: new.clone(),
-            });
         });
     }
 }
@@ -239,11 +144,9 @@ where
 {
     /// Forwards inserts as [`InsertMessage`].
     pub fn insert(&mut self) -> &mut Self {
-        match self.registrar.mode {
-            TableRegistrarMode::Init(_) => {
-                register_channel::<InsertMessage<TRow>>(self.registrar.expect_init());
-            }
-            TableRegistrarMode::Bind(_) => self.registrar.bind_insert::<TRow, TTable>(self.table),
+        match &mut self.registrar.mode {
+            RegistrarMode::Init(app) => register_channel::<InsertMessage<TRow>>(app),
+            RegistrarMode::Bind(world) => bind_insert::<TRow, TTable>(world, self.table),
         }
         self
     }
@@ -257,24 +160,18 @@ where
 {
     /// Forwards updates as [`UpdateMessage`].
     pub fn update(&mut self) -> &mut Self {
-        match self.registrar.mode {
-            TableRegistrarMode::Init(_) => {
-                register_channel::<UpdateMessage<TRow>>(self.registrar.expect_init());
-            }
-            TableRegistrarMode::Bind(_) => self.registrar.bind_update::<TRow, TTable>(self.table),
+        match &mut self.registrar.mode {
+            RegistrarMode::Init(app) => register_channel::<UpdateMessage<TRow>>(app),
+            RegistrarMode::Bind(world) => bind_update::<TRow, TTable>(world, self.table),
         }
         self
     }
 
     /// Forwards inserts and updates as [`InsertUpdateMessage`].
     pub fn insert_update(&mut self) -> &mut Self {
-        match self.registrar.mode {
-            TableRegistrarMode::Init(_) => {
-                register_channel::<InsertUpdateMessage<TRow>>(self.registrar.expect_init());
-            }
-            TableRegistrarMode::Bind(_) => self
-                .registrar
-                .bind_insert_update::<TRow, TTable>(self.table),
+        match &mut self.registrar.mode {
+            RegistrarMode::Init(app) => register_channel::<InsertUpdateMessage<TRow>>(app),
+            RegistrarMode::Bind(world) => bind_insert_update::<TRow, TTable>(world, self.table),
         }
         self
     }
@@ -287,12 +184,68 @@ where
 {
     /// Forwards deletes as [`DeleteMessage`].
     pub fn delete(&mut self) -> &mut Self {
-        match self.registrar.mode {
-            TableRegistrarMode::Init(_) => {
-                register_channel::<DeleteMessage<TRow>>(self.registrar.expect_init());
-            }
-            TableRegistrarMode::Bind(_) => self.registrar.bind_delete::<TRow, TTable>(self.table),
+        match &mut self.registrar.mode {
+            RegistrarMode::Init(app) => register_channel::<DeleteMessage<TRow>>(app),
+            RegistrarMode::Bind(world) => bind_delete::<TRow, TTable>(world, self.table),
         }
         self
     }
+}
+
+fn bind_insert<TRow, TTable>(world: &World, table: &TTable)
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow>,
+{
+    let sender = channel_sender::<InsertMessage<TRow>>(world);
+    table.on_insert(move |_ctx, row| {
+        let _ = sender.send(InsertMessage { row: row.clone() });
+    });
+}
+
+fn bind_delete<TRow, TTable>(world: &World, table: &TTable)
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow>,
+{
+    let sender = channel_sender::<DeleteMessage<TRow>>(world);
+    table.on_delete(move |_ctx, row| {
+        let _ = sender.send(DeleteMessage { row: row.clone() });
+    });
+}
+
+fn bind_update<TRow, TTable>(world: &World, table: &TTable)
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
+{
+    let sender = channel_sender::<UpdateMessage<TRow>>(world);
+    table.on_update(move |_ctx, old, new| {
+        let _ = sender.send(UpdateMessage {
+            old: old.clone(),
+            new: new.clone(),
+        });
+    });
+}
+
+fn bind_insert_update<TRow, TTable>(world: &World, table: &TTable)
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
+{
+    let sender_insert = channel_sender::<InsertUpdateMessage<TRow>>(world);
+    table.on_insert(move |_ctx, row| {
+        let _ = sender_insert.send(InsertUpdateMessage {
+            old: None,
+            new: row.clone(),
+        });
+    });
+
+    let sender_update = channel_sender::<InsertUpdateMessage<TRow>>(world);
+    table.on_update(move |_ctx, old, new| {
+        let _ = sender_update.send(InsertUpdateMessage {
+            old: Some(old.clone()),
+            new: new.clone(),
+        });
+    });
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -147,17 +147,68 @@ impl<'a> TableRegistrar<'a> {
         build(&mut builder);
     }
 
-    /// Returns the sender for the given message type and TableRegistrar mode.
+    /// Returns the sender for the given message type during runtime binding.
     fn sender<T>(&mut self) -> Sender<T>
     where
         T: Message,
     {
         match &mut self.mode {
-            TableRegistrarMode::Init(app) => {
-                register_channel::<T>(app);
-                channel_sender::<T>(app.world())
+            TableRegistrarMode::Init(_) => {
+                panic!("sender lookup is only valid during runtime table binding")
             }
             TableRegistrarMode::Bind(world) => channel_sender::<T>(world),
+        }
+    }
+
+    /// Registers insert forwarding for the given table.
+    fn register_insert<TRow>(&mut self)
+    where
+        TRow: Send + Sync + Clone + 'static,
+    {
+        match &mut self.mode {
+            TableRegistrarMode::Init(app) => {
+                register_channel::<InsertMessage<TRow>>(app);
+            }
+            _ => panic!("insert registration is only valid during table init"),
+        }
+    }
+
+    /// Registers delete forwarding for the given table.
+    fn register_delete<TRow>(&mut self)
+    where
+        TRow: Send + Sync + Clone + 'static,
+    {
+        match &mut self.mode {
+            TableRegistrarMode::Init(app) => {
+                register_channel::<DeleteMessage<TRow>>(app);
+            }
+            _ => panic!("delete registration is only valid during table init"),
+        }
+    }
+
+    /// Registers update forwarding for the given table.
+    fn register_update<TRow>(&mut self)
+    where
+        TRow: Send + Sync + Clone + 'static,
+    {
+        match &mut self.mode {
+            TableRegistrarMode::Init(app) => {
+                register_channel::<UpdateMessage<TRow>>(app);
+            }
+            _ => panic!("update registration is only valid during table init"),
+        }
+    }
+
+    /// Registers insert-or-update forwarding for the given table.
+    fn register_insert_update<TRow>(&mut self)
+    where
+        TRow: Send + Sync + Clone + 'static,
+    {
+        match &mut self.mode {
+            TableRegistrarMode::Init(app) => {
+                register_channel::<InsertUpdateMessage<TRow>>(app);
+            }
+            _ => panic!("insert_update registration is only valid during table init"),
         }
     }
 
@@ -232,7 +283,10 @@ where
 {
     /// Forwards inserts as [`InsertMessage`].
     pub fn insert(&mut self) -> &mut Self {
-        self.registrar.bind_insert::<TRow, TTable>(self.table);
+        match self.registrar.mode {
+            TableRegistrarMode::Init(_) => self.registrar.register_insert::<TRow>(),
+            TableRegistrarMode::Bind(_) => self.registrar.bind_insert::<TRow, TTable>(self.table),
+        }
         self
     }
 }
@@ -245,14 +299,21 @@ where
 {
     /// Forwards updates as [`UpdateMessage`].
     pub fn update(&mut self) -> &mut Self {
-        self.registrar.bind_update::<TRow, TTable>(self.table);
+        match self.registrar.mode {
+            TableRegistrarMode::Init(_) => self.registrar.register_update::<TRow>(),
+            TableRegistrarMode::Bind(_) => self.registrar.bind_update::<TRow, TTable>(self.table),
+        }
         self
     }
 
     /// Forwards inserts and updates as [`InsertUpdateMessage`].
     pub fn insert_update(&mut self) -> &mut Self {
-        self.registrar
-            .bind_insert_update::<TRow, TTable>(self.table);
+        match self.registrar.mode {
+            TableRegistrarMode::Init(_) => self.registrar.register_insert_update::<TRow>(),
+            TableRegistrarMode::Bind(_) => self
+                .registrar
+                .bind_insert_update::<TRow, TTable>(self.table),
+        }
         self
     }
 }
@@ -264,7 +325,10 @@ where
 {
     /// Forwards deletes as [`DeleteMessage`].
     pub fn delete(&mut self) -> &mut Self {
-        self.registrar.bind_delete::<TRow, TTable>(self.table);
+        match self.registrar.mode {
+            TableRegistrarMode::Init(_) => self.registrar.register_delete::<TRow>(),
+            TableRegistrarMode::Bind(_) => self.registrar.bind_delete::<TRow, TTable>(self.table),
+        }
         self
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -38,8 +38,8 @@ enum TableRegistrarMode<'a> {
 /// - [`TableBindingBuilder::delete`]
 ///
 /// Additional methods available only for tables with a primary key:
-/// - [`PkTableBindingBuilder::update`]
-/// - [`PkTableBindingBuilder::insert_update`]
+/// - [`TableBindingBuilder::update`]
+/// - [`TableBindingBuilder::insert_update`]
 pub struct TableBindingBuilder<'r, 't, TRow, TTable>
 where
     TRow: Send + Sync + Clone + 'static,

--- a/src/table.rs
+++ b/src/table.rs
@@ -168,38 +168,6 @@ impl<'a> TableRegistrar<'a> {
         }
     }
 
-    /// Registers insert forwarding for the given table.
-    fn register_insert<TRow>(&mut self)
-    where
-        TRow: Send + Sync + Clone + 'static,
-    {
-        register_channel::<InsertMessage<TRow>>(self.expect_init());
-    }
-
-    /// Registers delete forwarding for the given table.
-    fn register_delete<TRow>(&mut self)
-    where
-        TRow: Send + Sync + Clone + 'static,
-    {
-        register_channel::<DeleteMessage<TRow>>(self.expect_init());
-    }
-
-    /// Registers update forwarding for the given table.
-    fn register_update<TRow>(&mut self)
-    where
-        TRow: Send + Sync + Clone + 'static,
-    {
-        register_channel::<UpdateMessage<TRow>>(self.expect_init());
-    }
-
-    /// Registers insert-or-update forwarding for the given table.
-    fn register_insert_update<TRow>(&mut self)
-    where
-        TRow: Send + Sync + Clone + 'static,
-    {
-        register_channel::<InsertUpdateMessage<TRow>>(self.expect_init());
-    }
-
     /// Binds insert forwarding for the given table.
     fn bind_insert<TRow, TTable>(&mut self, table: &TTable)
     where
@@ -272,7 +240,9 @@ where
     /// Forwards inserts as [`InsertMessage`].
     pub fn insert(&mut self) -> &mut Self {
         match self.registrar.mode {
-            TableRegistrarMode::Init(_) => self.registrar.register_insert::<TRow>(),
+            TableRegistrarMode::Init(_) => {
+                register_channel::<InsertMessage<TRow>>(self.registrar.expect_init());
+            }
             TableRegistrarMode::Bind(_) => self.registrar.bind_insert::<TRow, TTable>(self.table),
         }
         self
@@ -288,7 +258,9 @@ where
     /// Forwards updates as [`UpdateMessage`].
     pub fn update(&mut self) -> &mut Self {
         match self.registrar.mode {
-            TableRegistrarMode::Init(_) => self.registrar.register_update::<TRow>(),
+            TableRegistrarMode::Init(_) => {
+                register_channel::<UpdateMessage<TRow>>(self.registrar.expect_init());
+            }
             TableRegistrarMode::Bind(_) => self.registrar.bind_update::<TRow, TTable>(self.table),
         }
         self
@@ -297,7 +269,9 @@ where
     /// Forwards inserts and updates as [`InsertUpdateMessage`].
     pub fn insert_update(&mut self) -> &mut Self {
         match self.registrar.mode {
-            TableRegistrarMode::Init(_) => self.registrar.register_insert_update::<TRow>(),
+            TableRegistrarMode::Init(_) => {
+                register_channel::<InsertUpdateMessage<TRow>>(self.registrar.expect_init());
+            }
             TableRegistrarMode::Bind(_) => self
                 .registrar
                 .bind_insert_update::<TRow, TTable>(self.table),
@@ -314,7 +288,9 @@ where
     /// Forwards deletes as [`DeleteMessage`].
     pub fn delete(&mut self) -> &mut Self {
         match self.registrar.mode {
-            TableRegistrarMode::Init(_) => self.registrar.register_delete::<TRow>(),
+            TableRegistrarMode::Init(_) => {
+                register_channel::<DeleteMessage<TRow>>(self.registrar.expect_init());
+            }
             TableRegistrarMode::Bind(_) => self.registrar.bind_delete::<TRow, TTable>(self.table),
         }
         self

--- a/src/table.rs
+++ b/src/table.rs
@@ -20,9 +20,6 @@ pub(crate) enum RegistrarMode<'a> {
     Bind(&'a World),
 }
 
-pub trait NonEventTable {}
-impl<T> NonEventTable for T where T: Table + ?Sized {}
-
 /// Registers SpacetimeDB table callbacks as Bevy messages.
 ///
 /// Registration runs once to initialize channels and again to bind callbacks
@@ -180,7 +177,7 @@ where
 impl<'r, 't, TRow, TTable> TableBindingBuilder<'r, 't, TRow, TTable>
 where
     TRow: Send + Sync + Clone + 'static,
-    TTable: Table<Row = TRow> + NonEventTable,
+    TTable: Table<Row = TRow>,
 {
     /// Forwards deletes as [`DeleteMessage`].
     pub fn delete(&mut self) -> &mut Self {

--- a/src/table.rs
+++ b/src/table.rs
@@ -28,25 +28,6 @@ pub struct TableRegistrar<'a> {
     mode: RegistrarMode<'a>,
 }
 
-/// Builder for configuring which table events should be forwarded.
-///
-/// Base methods available for all tables:
-/// - [`TableBindingBuilder::insert`]
-///
-/// Additional methods available only for tables with a primary key:
-/// - [`TableBindingBuilder::update`]
-/// - [`TableBindingBuilder::insert_update`]
-/// - [`TableBindingBuilder::delete`]
-pub struct TableBindingBuilder<'r, 't, TRow, TTable>
-where
-    TRow: Send + Sync + Clone + 'static,
-    TTable: Table<Row = TRow>,
-{
-    registrar: &'r mut TableRegistrar<'t>,
-    table: &'r TTable,
-    _row: PhantomData<TRow>,
-}
-
 impl<'a> TableRegistrar<'a> {
     /// Creates a new [`TableRegistrar`] with the given mode.
     pub(crate) fn new(mode: RegistrarMode<'a>) -> Self {
@@ -108,16 +89,7 @@ impl<'a> TableRegistrar<'a> {
         });
     }
 
-    /// Registers a table using a configurable builder.
-    ///
-    /// Base bindings available for all tables:
-    /// - [`TableBindingBuilder::insert`]
-    ///
-    /// Additional bindings become available when the table satisfies the
-    /// required trait bounds:
-    /// - [`TableBindingBuilder::delete`] for non-event tables
-    /// - [`TableBindingBuilder::update`] for tables with a primary key
-    /// - [`TableBindingBuilder::insert_update`] for tables with a primary key
+    /// Use [`TableBindingBuilder`] to select which messages to forward.
     pub fn build<TRow, TTable>(
         &mut self,
         table: &TTable,
@@ -132,6 +104,17 @@ impl<'a> TableRegistrar<'a> {
             _row: PhantomData,
         });
     }
+}
+
+/// Builder for configuring which table events should be forwarded.
+pub struct TableBindingBuilder<'r, 't, TRow, TTable>
+where
+    TRow: Send + Sync + Clone + 'static,
+    TTable: Table<Row = TRow>,
+{
+    registrar: &'r mut TableRegistrar<'t>,
+    table: &'r TTable,
+    _row: PhantomData<TRow>,
 }
 
 impl<'r, 't, TRow, TTable> TableBindingBuilder<'r, 't, TRow, TTable>


### PR DESCRIPTION
Internally require invariant that register only registers and the channel sender requires you have registered beforehand. 

Add a builder method so people can micro-optimize by specifying the exact events they want to bind to. 


So this allows consumers to do this:

```rust
.with_tables(|reg, db| {
  // Table with pk has access to all events
  // reg.table(&db.slick_view());
  reg.build(&db.cool_table_with_pk(), |bind| {
    bind.insert();
    bind.update();
    bind.insert_update();
    bind.delete();
  });

  // View or table without pk has access to insert/delete
  // reg.view(&db.slick_view());
  reg.build(&db.slick_view(), |bind| {
    bind.insert();
    bind.delete();
  });

  // Event table has access to insert
  // reg.event_table(&db.wow_event_table())
  reg.build(&db.wow_event_table(), |bind| {
    bind.insert();
  });
});
```