### PR TITLE
chore: improve subscription perf and data lapse

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs,
     system::{Res, ResMut},
 };
-use bevy_state::{condition::in_state, state::OnEnter};
+use bevy_state::state::OnEnter;
 use spacetimedb_sdk::{
     __codegen::{__query_builder::Query, DbConnection, SpacetimeModule, SubscriptionBuilder},
     DbContext, Result as StdbResult, SubscriptionHandle as StdbSubscriptionHandle,
@@ -83,7 +83,10 @@ where
     pub fn unsubscribe(&mut self, key: &K) -> StdbResult<()> {
         self.sql_by_key.remove(key);
         self.queued_keys.remove(key);
-        self.drop_active_handle(key)
+        if let Some(handle) = self.handles.remove(key) {
+            handle.unsubscribe()?;
+        };
+        Ok(())
     }
 
     /// Unsubscribes all active handles and clears all stored queries.
@@ -131,9 +134,7 @@ where
 
     /// Queues all stored subscriptions to be applied again.
     pub(crate) fn queue_all(&mut self) {
-        for key in self.sql_by_key.keys().cloned() {
-            self.queued_keys.insert(key);
-        }
+        self.queued_keys.extend(self.sql_by_key.keys().cloned());
     }
 
     /// Applies queued subscriptions to the active connection.
@@ -146,25 +147,15 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
-        let keys: Vec<K> = self.queued_keys.drain().collect();
-
+        let keys = std::mem::take(&mut self.queued_keys);
         for key in keys {
-            let Some(sql) = self.sql_by_key.get(&key).cloned() else {
-                continue;
-            };
-
-            let _ = self.drop_active_handle(&key);
-            let handle = conn.subscription_builder().subscribe(sql);
-            self.handles.insert(key, handle);
+            if let Some(sql) = self.sql_by_key.get(&key) {
+                let handle = conn.subscription_builder().subscribe(sql.as_str());
+                if let Some(old_handle) = self.handles.insert(key, handle) {
+                    let _ = old_handle.unsubscribe();
+                }
+            }
         }
-    }
-
-    /// Unsubscribes and removes the active handle for `key` without removing its stored query.
-    fn drop_active_handle(&mut self, key: &K) -> StdbResult<()> {
-        if let Some(handle) = self.handles.remove(key) {
-            handle.unsubscribe()?;
-        }
-        Ok(())
     }
 }
 
@@ -231,9 +222,21 @@ where
 
         app.add_systems(
             PreUpdate,
-            apply_queued_subscriptions::<K, C, M>.run_if(in_state(StdbConnectionState::Connected)),
+            apply_queued_subscriptions::<K, C, M>.run_if(should_apply_subscriptions::<K, M>),
         );
     }
+}
+
+fn should_apply_subscriptions<K, M>(
+    subs: Res<StdbSubscriptions<K, M>>,
+    state: Res<bevy_state::state::State<StdbConnectionState>>,
+) -> bool
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    M: SpacetimeModule,
+    M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
+{
+    !subs.queued_keys.is_empty() && *state.get() == StdbConnectionState::Connected
 }
 
 /// Re-queues stored subscriptions after a disconnect.

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -14,13 +14,19 @@ use spacetimedb_sdk::{
     __codegen::{__query_builder::Query, DbConnection, SpacetimeModule, SubscriptionBuilder},
     DbContext, Result as StdbResult, SubscriptionHandle as StdbSubscriptionHandle,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    hash::Hash,
-    marker::PhantomData,
-};
+use std::{collections::HashMap, hash::Hash, marker::PhantomData};
 
 type SubscriptionInitializer<K, M> = dyn Fn(&mut StdbSubscriptions<K, M>) + Send + Sync;
+
+/// Stored subscription intent and active handle for a single key.
+struct SubscriptionEntry<H> {
+    /// Active handle for the current connection, if any.
+    handle: Option<H>,
+    /// Stored SQL query.
+    sql: String,
+    /// Whether this subscription should be applied on the next active connection.
+    queued: bool,
+}
 
 /// A [`Resource`] that stores SpacetimeDB subscriptions in Bevy.
 ///
@@ -33,12 +39,8 @@ where
     M: SpacetimeModule,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    /// Active handles for the current connection.
-    handles: HashMap<K, M::SubscriptionHandle>,
-    /// Stored SQL for each subscription key.
-    sql_by_key: HashMap<K, String>,
-    /// Keys queued to be applied on the next active connection.
-    queued_keys: HashSet<K>,
+    /// Stored subscription entries keyed by logical subscription key.
+    entries: HashMap<K, SubscriptionEntry<M::SubscriptionHandle>>,
 }
 
 impl<K, M> Default for StdbSubscriptions<K, M>
@@ -49,9 +51,7 @@ where
 {
     fn default() -> Self {
         Self {
-            handles: HashMap::new(),
-            sql_by_key: HashMap::new(),
-            queued_keys: HashSet::new(),
+            entries: HashMap::new(),
         }
     }
 }
@@ -75,17 +75,35 @@ where
     /// Stores a SQL query for `key` and queues it to be applied.
     pub fn subscribe_sql(&mut self, key: K, sql: impl Into<String>) {
         let sql = sql.into();
-        self.sql_by_key.insert(key.clone(), sql);
-        self.queued_keys.insert(key);
+
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.sql = sql;
+            entry.queued = true;
+            return;
+        }
+
+        self.entries.insert(
+            key,
+            SubscriptionEntry {
+                handle: None,
+                sql,
+                queued: true,
+            },
+        );
     }
 
     /// Unsubscribes `key` and removes its stored query.
     pub fn unsubscribe(&mut self, key: &K) -> StdbResult<()> {
-        self.sql_by_key.remove(key);
-        self.queued_keys.remove(key);
-        if let Some(handle) = self.handles.remove(key) {
-            handle.unsubscribe()?;
+        let Some(mut entry) = self.entries.remove(key) else {
+            return Ok(());
         };
+
+        entry.queued = false;
+
+        if let Some(handle) = entry.handle.take() {
+            handle.unsubscribe()?;
+        }
+
         Ok(())
     }
 
@@ -95,18 +113,17 @@ where
     pub fn unsubscribe_all(&mut self) -> StdbResult<()> {
         let mut first_err = None;
 
-        for (_, handle) in self.handles.drain() {
-            let Err(err) = handle.unsubscribe() else {
-                continue;
-            };
+        for (_, mut entry) in self.entries.drain() {
+            if let Some(handle) = entry.handle.take() {
+                let Err(err) = handle.unsubscribe() else {
+                    continue;
+                };
 
-            if first_err.is_none() {
-                first_err = Some(err);
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
             }
         }
-
-        self.sql_by_key.clear();
-        self.queued_keys.clear();
 
         if let Some(err) = first_err {
             Err(err)
@@ -117,24 +134,25 @@ where
 
     /// Returns the stored SQL query for `key`, if any.
     pub fn sql_for(&self, key: &K) -> Option<&str> {
-        self.sql_by_key.get(key).map(String::as_str)
+        self.entries.get(key).map(|entry| entry.sql.as_str())
     }
 
     /// Returns `true` if `key` has queued subscription work.
     pub fn is_queued(&self, key: &K) -> bool {
-        self.queued_keys.contains(key)
+        self.entries.get(key).is_some_and(|entry| entry.queued)
     }
 
     /// Returns `true` if `key` has an active subscription handle.
     pub fn is_active(&self, key: &K) -> bool {
-        self.handles
+        self.entries
             .get(key)
+            .and_then(|entry| entry.handle.as_ref())
             .is_some_and(|handle| handle.is_active())
     }
 
-    /// Queues all stored subscriptions to be applied again.
-    pub(crate) fn queue_all(&mut self) {
-        self.queued_keys.extend(self.sql_by_key.keys().cloned());
+    /// Returns `true` if any subscription has queued work.
+    pub(crate) fn has_queued(&self) -> bool {
+        self.entries.values().any(|entry| entry.queued)
     }
 
     /// Applies queued subscriptions to the active connection.
@@ -147,14 +165,16 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
-        let keys = std::mem::take(&mut self.queued_keys);
-        for key in keys {
-            if let Some(sql) = self.sql_by_key.get(&key) {
-                let handle = conn.subscription_builder().subscribe(sql.as_str());
-                if let Some(old_handle) = self.handles.insert(key, handle) {
-                    let _ = old_handle.unsubscribe();
-                }
+        for entry in self.entries.values_mut() {
+            if !entry.queued {
+                continue;
             }
+
+            let handle = conn.subscription_builder().subscribe(entry.sql.as_str());
+            if let Some(old_handle) = entry.handle.replace(handle) {
+                let _ = old_handle.unsubscribe();
+            }
+            entry.queued = false;
         }
     }
 }
@@ -236,7 +256,7 @@ where
     M: SpacetimeModule,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    !subs.queued_keys.is_empty() && *state.get() == StdbConnectionState::Connected
+    subs.has_queued() && *state.get() == StdbConnectionState::Connected
 }
 
 /// Re-queues stored subscriptions after a disconnect.
@@ -246,11 +266,13 @@ where
     M: SpacetimeModule,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    for (_, handle) in subs.handles.drain() {
-        let _ = handle.unsubscribe();
-    }
+    for entry in subs.entries.values_mut() {
+        if let Some(handle) = entry.handle.take() {
+            let _ = handle.unsubscribe();
+        }
 
-    subs.queue_all();
+        entry.queued = true;
+    }
 }
 
 /// Applies queued subscriptions to the current connection.


### PR DESCRIPTION
Summary

Improves subscription handling by reducing unnecessary work in the steady-state path, cutting allocation/churn during reapplication, and tightening subscription replacement behavior to avoid data lapse.

## Changes

- add a custom run condition so queued subscriptions are only applied when there is actual queued work
- replace the multi-collection subscription model with a single entry per key
- remove extra allocation/churn when applying queued subscriptions
- subscribe the replacement handle before unsubscribing the previous one, matching SpacetimeDB guidance and reducing lapse risk

## Why

Previously, subscription state was coordinated across multiple collections:
- active handles
- stored SQL
- queued keys

That worked, but it duplicated key storage and required more coordination during apply/reconnect flows.

This change moves subscription state to a single per-key entry that stores:
- sql
- active handle
- queued status

That simplifies invariants, reduces cloning/allocation, and makes the reconnect/apply path easier to reason about.

## Behavior impact

No intended API change.

Runtime behavior is improved in two ways:
- the apply system no longer runs every connected frame when there is no queued work
- replacing an active subscription now subscribes first and unsubscribes the old handle second, which better avoids temporary subscription gaps

## Notes

This is primarily a cleanup/perf/invariant improvement for the subscription lifecycle rather than a feature change.