### PR TITLE
fix: only resubscribe on disconnect for those that are valid handles

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -269,9 +269,8 @@ where
     for entry in subs.entries.values_mut() {
         if let Some(handle) = entry.handle.take() {
             let _ = handle.unsubscribe();
+            entry.queued = true;
         }
-
-        entry.queued = true;
     }
 }
 


### PR DESCRIPTION
Should only re-queue active handles... ATM it re-queues everything despite the current state / intents.