### PR TITLE
feat: messages for applied and error subscription callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_stdb"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bevy_app",
  "bevy_ecs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_stdb"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.93"
 description = "A Bevy-native integration for SpacetimeDB with table messages, subscriptions, and reconnect support."

--- a/README.md
+++ b/README.md
@@ -192,7 +192,20 @@ That means you can:
 - queue additional subscriptions later from normal Bevy systems
 - automatically re-apply queued subscription intent after reconnect
 
-Subscriptions are keyed, so you can refer to them using domain-specific identifiers to do things like resubscribe dynamically or unsubscribe.
+Subscriptions are keyed, so you can refer to them using domain-specific identifiers to do things like resubscribe dynamically or unsubscribe. 
+
+There are also messages that are emitted for the `on_applied` and `on_error` callbacks for each subscription. 
+
+```rust
+// Check the client cache once a particular subscription has been applied.
+fn on_applied(mut applied_msgs: ReadStdbSubscriptionAppliedMessage<SubKey>, conn: Res<StdbConn>) {
+  for message in applied_messages.read() {
+    if message.is(&SubKey::MyCharacters) {
+      println!("You have {} characters.", conn.db().my_characters().count());
+    }
+  }
+}
+```
 
 ## Reconnects
 

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,7 +1,8 @@
 //! [`MessageReader`] type aliases for connection lifecycle and table messages.
 use crate::message::{
     DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
-    StdbConnectionErrorMessage, StdbDisconnectedMessage, UpdateMessage,
+    StdbConnectionErrorMessage, StdbDisconnectedMessage, StdbSubscriptionAppliedMessage,
+    StdbSubscriptionErrorMessage, UpdateMessage,
 };
 use bevy_ecs::prelude::MessageReader;
 
@@ -25,3 +26,11 @@ pub type ReadStdbDisconnectedMessage<'w, 's> = MessageReader<'w, 's, StdbDisconn
 
 /// A [`MessageReader`] for [`StdbConnectionErrorMessage`].
 pub type ReadStdbConnectionErrorMessage<'w, 's> = MessageReader<'w, 's, StdbConnectionErrorMessage>;
+
+/// A [`MessageReader`] for [`StdbSubscriptionAppliedMessage<K>`].
+pub type ReadStdbSubscriptionAppliedMessage<'w, 's, K> =
+    MessageReader<'w, 's, StdbSubscriptionAppliedMessage<K>>;
+
+/// A [`MessageReader`] for [`StdbSubscriptionErrorMessage<K>`].
+pub type ReadStdbSubscriptionErrorMessage<'w, 's, K> =
+    MessageReader<'w, 's, StdbSubscriptionErrorMessage<K>>;

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,8 +1,8 @@
 //! [`MessageReader`] type aliases for connection lifecycle and table messages.
 use crate::message::{
     DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
-    StdbConnectionErrorMessage, StdbDisconnectedMessage, StdbSubAppliedMessage,
-    StdbSubErrorMessage, UpdateMessage,
+    StdbConnectionErrorMessage, StdbDisconnectedMessage, StdbSubscriptionAppliedMessage,
+    StdbSubscriptionErrorMessage, UpdateMessage,
 };
 use bevy_ecs::prelude::MessageReader;
 
@@ -28,7 +28,9 @@ pub type ReadStdbDisconnectedMessage<'w, 's> = MessageReader<'w, 's, StdbDisconn
 pub type ReadStdbConnectionErrorMessage<'w, 's> = MessageReader<'w, 's, StdbConnectionErrorMessage>;
 
 /// A [`MessageReader`] for [`StdbSubscriptionAppliedMessage<K>`].
-pub type ReadStdbSubAppliedMessage<'w, 's, K> = MessageReader<'w, 's, StdbSubAppliedMessage<K>>;
+pub type ReadStdbSubscriptionAppliedMessage<'w, 's, K> =
+    MessageReader<'w, 's, StdbSubscriptionAppliedMessage<K>>;
 
 /// A [`MessageReader`] for [`StdbSubscriptionErrorMessage<K>`].
-pub type ReadStdbSubErrorMessage<'w, 's, K> = MessageReader<'w, 's, StdbSubErrorMessage<K>>;
+pub type ReadStdbSubscriptionErrorMessage<'w, 's, K> =
+    MessageReader<'w, 's, StdbSubscriptionErrorMessage<K>>;

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,8 +1,8 @@
 //! [`MessageReader`] type aliases for connection lifecycle and table messages.
 use crate::message::{
     DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
-    StdbConnectionErrorMessage, StdbDisconnectedMessage, StdbSubscriptionAppliedMessage,
-    StdbSubscriptionErrorMessage, UpdateMessage,
+    StdbConnectionErrorMessage, StdbDisconnectedMessage, StdbSubAppliedMessage,
+    StdbSubErrorMessage, UpdateMessage,
 };
 use bevy_ecs::prelude::MessageReader;
 
@@ -28,9 +28,7 @@ pub type ReadStdbDisconnectedMessage<'w, 's> = MessageReader<'w, 's, StdbDisconn
 pub type ReadStdbConnectionErrorMessage<'w, 's> = MessageReader<'w, 's, StdbConnectionErrorMessage>;
 
 /// A [`MessageReader`] for [`StdbSubscriptionAppliedMessage<K>`].
-pub type ReadStdbSubscriptionAppliedMessage<'w, 's, K> =
-    MessageReader<'w, 's, StdbSubscriptionAppliedMessage<K>>;
+pub type ReadStdbSubAppliedMessage<'w, 's, K> = MessageReader<'w, 's, StdbSubAppliedMessage<K>>;
 
 /// A [`MessageReader`] for [`StdbSubscriptionErrorMessage<K>`].
-pub type ReadStdbSubscriptionErrorMessage<'w, 's, K> =
-    MessageReader<'w, 's, StdbSubscriptionErrorMessage<K>>;
+pub type ReadStdbSubErrorMessage<'w, 's, K> = MessageReader<'w, 's, StdbSubErrorMessage<K>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,10 @@ pub mod prelude {
             ReadUpdateMessage,
         },
         connection::{StdbConnection, StdbConnectionController, StdbConnectionState},
+        message::{
+            DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
+            StdbConnectionErrorMessage, StdbDisconnectedMessage, UpdateMessage,
+        },
         plugin::StdbPlugin,
         reconnect::StdbReconnectOptions,
         set::StdbSet,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,16 +78,9 @@ mod table;
 /// Common imports for `bevy_stdb`.
 pub mod prelude {
     pub use crate::{
-        alias::{
-            ReadDeleteMessage, ReadInsertMessage, ReadInsertUpdateMessage,
-            ReadStdbConnectedMessage, ReadStdbConnectionErrorMessage, ReadStdbDisconnectedMessage,
-            ReadUpdateMessage,
-        },
+        alias::*,
         connection::{StdbConnection, StdbConnectionController, StdbConnectionState},
-        message::{
-            DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
-            StdbConnectionErrorMessage, StdbDisconnectedMessage, UpdateMessage,
-        },
+        message::*,
         plugin::StdbPlugin,
         reconnect::StdbReconnectOptions,
         set::StdbSet,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,8 @@ pub mod prelude {
         connection::{StdbConnection, StdbConnectionController, StdbConnectionState},
         message::{
             DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectedMessage,
-            StdbConnectionErrorMessage, StdbDisconnectedMessage, UpdateMessage,
+            StdbConnectionErrorMessage, StdbDisconnectedMessage, StdbSubscriptionAppliedMessage,
+            StdbSubscriptionErrorMessage, UpdateMessage,
         },
         plugin::StdbPlugin,
         reconnect::StdbReconnectOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,13 @@ mod table;
 /// Common imports for `bevy_stdb`.
 pub mod prelude {
     pub use crate::{
-        alias::*,
+        alias::{
+            ReadDeleteMessage, ReadInsertMessage, ReadInsertUpdateMessage,
+            ReadStdbConnectedMessage, ReadStdbConnectionErrorMessage, ReadStdbDisconnectedMessage,
+            ReadStdbSubscriptionAppliedMessage, ReadStdbSubscriptionErrorMessage,
+            ReadUpdateMessage,
+        },
         connection::{StdbConnection, StdbConnectionController, StdbConnectionState},
-        message::*,
         plugin::StdbPlugin,
         reconnect::StdbReconnectOptions,
         set::StdbSet,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,4 @@
-//! Bevy message types for SpacetimeDB connection lifecycle and table events.
+//! Bevy message types for SpacetimeDB connection, subscription, and table events.
 use bevy_ecs::prelude::Message;
 use spacetimedb_sdk::{Error, Identity};
 
@@ -23,6 +23,36 @@ pub struct StdbDisconnectedMessage {
 pub struct StdbConnectionErrorMessage {
     /// The connection error.
     pub err: Error,
+}
+
+/// A [`Message`] sent when a subscription is applied.
+#[derive(Message, Clone, Debug)]
+pub struct StdbSubscriptionAppliedMessage<K> {
+    /// The subscription key associated with the applied subscription.
+    pub key: K,
+}
+
+impl<K: PartialEq> StdbSubscriptionAppliedMessage<K> {
+    /// Returns `true` when this message belongs to `key`.
+    pub fn is(&self, key: &K) -> bool {
+        &self.key == key
+    }
+}
+
+/// A [`Message`] sent when a subscription application fails.
+#[derive(Message, Clone, Debug)]
+pub struct StdbSubscriptionErrorMessage<K> {
+    /// The subscription key associated with the failed subscription.
+    pub key: K,
+    /// The subscription error.
+    pub err: Error,
+}
+
+impl<K: PartialEq> StdbSubscriptionErrorMessage<K> {
+    /// Returns `true` when this message belongs to `key`.
+    pub fn is(&self, key: &K) -> bool {
+        &self.key == key
+    }
 }
 
 /// A [`Message`] sent when a row is inserted into a subscribed table.

--- a/src/message.rs
+++ b/src/message.rs
@@ -27,12 +27,12 @@ pub struct StdbConnectionErrorMessage {
 
 /// A [`Message`] sent when a subscription is applied.
 #[derive(Message, Clone, Debug)]
-pub struct StdbSubAppliedMessage<K> {
+pub struct StdbSubscriptionAppliedMessage<K> {
     /// The subscription key associated with the applied subscription.
     pub key: K,
 }
 
-impl<K: PartialEq> StdbSubAppliedMessage<K> {
+impl<K: PartialEq> StdbSubscriptionAppliedMessage<K> {
     /// Returns `true` when this message belongs to `key`.
     pub fn is(&self, key: &K) -> bool {
         &self.key == key
@@ -41,14 +41,14 @@ impl<K: PartialEq> StdbSubAppliedMessage<K> {
 
 /// A [`Message`] sent when a subscription application fails.
 #[derive(Message, Clone, Debug)]
-pub struct StdbSubErrorMessage<K> {
+pub struct StdbSubscriptionErrorMessage<K> {
     /// The subscription key associated with the failed subscription.
     pub key: K,
     /// The subscription error.
     pub err: Error,
 }
 
-impl<K: PartialEq> StdbSubErrorMessage<K> {
+impl<K: PartialEq> StdbSubscriptionErrorMessage<K> {
     /// Returns `true` when this message belongs to `key`.
     pub fn is(&self, key: &K) -> bool {
         &self.key == key

--- a/src/message.rs
+++ b/src/message.rs
@@ -27,12 +27,12 @@ pub struct StdbConnectionErrorMessage {
 
 /// A [`Message`] sent when a subscription is applied.
 #[derive(Message, Clone, Debug)]
-pub struct StdbSubscriptionAppliedMessage<K> {
+pub struct StdbSubAppliedMessage<K> {
     /// The subscription key associated with the applied subscription.
     pub key: K,
 }
 
-impl<K: PartialEq> StdbSubscriptionAppliedMessage<K> {
+impl<K: PartialEq> StdbSubAppliedMessage<K> {
     /// Returns `true` when this message belongs to `key`.
     pub fn is(&self, key: &K) -> bool {
         &self.key == key
@@ -41,14 +41,14 @@ impl<K: PartialEq> StdbSubscriptionAppliedMessage<K> {
 
 /// A [`Message`] sent when a subscription application fails.
 #[derive(Message, Clone, Debug)]
-pub struct StdbSubscriptionErrorMessage<K> {
+pub struct StdbSubErrorMessage<K> {
     /// The subscription key associated with the failed subscription.
     pub key: K,
     /// The subscription error.
     pub err: Error,
 }
 
-impl<K: PartialEq> StdbSubscriptionErrorMessage<K> {
+impl<K: PartialEq> StdbSubErrorMessage<K> {
     /// Returns `true` when this message belongs to `key`.
     pub fn is(&self, key: &K) -> bool {
         &self.key == key

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -4,6 +4,7 @@
 use crate::{
     channel_bridge::{channel_sender, register_channel},
     connection::{StdbConnection, StdbConnectionState},
+    message::{StdbSubscriptionAppliedMessage, StdbSubscriptionErrorMessage},
     set::StdbSet,
 };
 use bevy_app::{App, Plugin, PreUpdate};
@@ -35,8 +36,8 @@ struct SubscriptionMessageSenders<K>
 where
     K: Clone + Send + Sync + 'static,
 {
-    applied: Sender<crate::message::StdbSubscriptionAppliedMessage<K>>,
-    error: Sender<crate::message::StdbSubscriptionErrorMessage<K>>,
+    applied: Sender<StdbSubscriptionAppliedMessage<K>>,
+    error: Sender<StdbSubscriptionErrorMessage<K>>,
 }
 
 /// Configures a queued subscription registration.
@@ -224,11 +225,11 @@ where
             let handle = conn
                 .subscription_builder()
                 .on_applied(move |_ctx| {
-                    let _ = applied_sender
-                        .send(crate::message::StdbSubscriptionAppliedMessage { key: applied_key });
+                    let _ =
+                        applied_sender.send(StdbSubscriptionAppliedMessage { key: applied_key });
                 })
                 .on_error(move |_ctx, err| {
-                    let _ = error_sender.send(crate::message::StdbSubscriptionErrorMessage {
+                    let _ = error_sender.send(StdbSubscriptionErrorMessage {
                         key: error_key,
                         err,
                     });
@@ -294,13 +295,13 @@ where
 {
     /// Installs the subscription resource and lifecycle systems.
     fn build(&self, app: &mut App) {
-        register_channel::<crate::message::StdbSubscriptionAppliedMessage<K>>(app);
-        register_channel::<crate::message::StdbSubscriptionErrorMessage<K>>(app);
+        register_channel::<StdbSubscriptionAppliedMessage<K>>(app);
+        register_channel::<StdbSubscriptionErrorMessage<K>>(app);
 
         let world = app.world();
         let senders = SubscriptionMessageSenders {
-            applied: channel_sender::<crate::message::StdbSubscriptionAppliedMessage<K>>(world),
-            error: channel_sender::<crate::message::StdbSubscriptionErrorMessage<K>>(world),
+            applied: channel_sender::<StdbSubscriptionAppliedMessage<K>>(world),
+            error: channel_sender::<StdbSubscriptionErrorMessage<K>>(world),
         };
 
         app.insert_resource(senders);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -156,11 +156,7 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
-        for (key, entry) in self.entries.iter_mut() {
-            if !entry.queued {
-                continue;
-            }
-
+        for (key, entry) in self.entries.iter_mut().filter(|(_, entry)| entry.queued) {
             let applied_key = key.clone();
             let applied_sender = self.applied_sender.clone();
             let error_key = key.clone();

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -4,7 +4,7 @@
 use crate::{
     channel_bridge::{channel_sender, register_channel},
     connection::{StdbConnection, StdbConnectionState},
-    message::{StdbSubAppliedMessage, StdbSubErrorMessage},
+    message::{StdbSubscriptionAppliedMessage, StdbSubscriptionErrorMessage},
     set::StdbSet,
 };
 use bevy_app::{App, Plugin, PreUpdate};
@@ -44,9 +44,9 @@ where
     /// Subscription entries keyed by user-defined subscription key.
     entries: HashMap<K, SubscriptionEntry<M::SubscriptionHandle>>,
     /// Sender for subscription applied lifecycle messages.
-    applied_sender: Sender<StdbSubAppliedMessage<K>>,
+    applied_sender: Sender<StdbSubscriptionAppliedMessage<K>>,
     /// Sender for subscription error lifecycle messages.
-    error_sender: Sender<StdbSubErrorMessage<K>>,
+    error_sender: Sender<StdbSubscriptionErrorMessage<K>>,
 }
 
 impl<K, M> StdbSubscriptions<K, M>
@@ -165,10 +165,11 @@ where
             let handle = conn
                 .subscription_builder()
                 .on_applied(move |_ctx| {
-                    let _ = applied_sender.send(StdbSubAppliedMessage { key: applied_key });
+                    let _ =
+                        applied_sender.send(StdbSubscriptionAppliedMessage { key: applied_key });
                 })
                 .on_error(move |_ctx, err| {
-                    let _ = error_sender.send(StdbSubErrorMessage {
+                    let _ = error_sender.send(StdbSubscriptionErrorMessage {
                         key: error_key,
                         err,
                     });
@@ -234,14 +235,14 @@ where
 {
     /// Installs the subscription resource and lifecycle systems.
     fn build(&self, app: &mut App) {
-        register_channel::<StdbSubAppliedMessage<K>>(app);
-        register_channel::<StdbSubErrorMessage<K>>(app);
+        register_channel::<StdbSubscriptionAppliedMessage<K>>(app);
+        register_channel::<StdbSubscriptionErrorMessage<K>>(app);
 
         let world = app.world();
         app.insert_resource(StdbSubscriptions::<K, M> {
             entries: HashMap::default(),
-            applied_sender: channel_sender::<StdbSubAppliedMessage<K>>(world),
-            error_sender: channel_sender::<StdbSubErrorMessage<K>>(world),
+            applied_sender: channel_sender::<StdbSubscriptionAppliedMessage<K>>(world),
+            error_sender: channel_sender::<StdbSubscriptionErrorMessage<K>>(world),
         });
 
         let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -228,7 +228,7 @@ where
 
 impl<K, C, M> Plugin for SubscriptionsPlugin<K, C, M>
 where
-    K: Eq + Hash + Clone + PartialEq + Send + Sync + 'static,
+    K: Eq + Hash + Clone + Send + Sync + 'static,
     C: DbConnection<Module = M>
         + DbContext<SubscriptionBuilder = SubscriptionBuilder<M>>
         + Send

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -40,17 +40,6 @@ where
     error: Sender<StdbSubscriptionErrorMessage<K>>,
 }
 
-/// Configures a queued subscription registration.
-pub struct SubscriptionRegistration<'a, K, M>
-where
-    K: Eq + Hash + Clone + Send + Sync + 'static,
-    M: SpacetimeModule,
-    M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
-{
-    _key: K,
-    _subs: &'a mut StdbSubscriptions<K, M>,
-}
-
 /// SpacetimeDB subscription [`Resource`].
 ///
 /// Keeps subscription intent separate from active handles so queries can be
@@ -86,50 +75,33 @@ where
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
     /// Stores a typed query for `key` and queues it to be applied.
-    pub fn subscribe_query<T, Q>(
-        &mut self,
-        key: K,
-        query: impl Fn(M::QueryBuilder) -> Q,
-    ) -> SubscriptionRegistration<'_, K, M>
+    pub fn subscribe_query<T, Q>(&mut self, key: K, query: impl Fn(M::QueryBuilder) -> Q)
     where
         Q: Query<T>,
     {
         let res = query(M::QueryBuilder::default());
         let sql = Query::into_sql(res);
-        self.subscribe_sql(key, sql)
+        self.subscribe_sql(key, sql);
     }
 
     /// Stores a SQL query for `key` and queues it to be applied.
-    pub fn subscribe_sql(
-        &mut self,
-        key: K,
-        sql: impl Into<String>,
-    ) -> SubscriptionRegistration<'_, K, M> {
+    pub fn subscribe_sql(&mut self, key: K, sql: impl Into<String>) {
         let sql = sql.into();
 
         if let Some(entry) = self.entries.get_mut(&key) {
             entry.sql = sql;
             entry.queued = true;
-
-            return SubscriptionRegistration {
-                _key: key,
-                _subs: self,
-            };
+            return;
         }
 
         self.entries.insert(
-            key.clone(),
+            key,
             SubscriptionEntry {
                 handle: None,
                 sql,
                 queued: true,
             },
         );
-
-        SubscriptionRegistration {
-            _key: key,
-            _subs: self,
-        }
     }
 
     /// Unsubscribes `key` and removes its stored query.

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -44,24 +44,9 @@ where
     /// Subscription entries keyed by user-defined subscription key.
     entries: HashMap<K, SubscriptionEntry<M::SubscriptionHandle>>,
     /// Sender for subscription applied lifecycle messages.
-    applied_sender: Option<Sender<StdbSubscriptionAppliedMessage<K>>>,
+    applied_sender: Sender<StdbSubscriptionAppliedMessage<K>>,
     /// Sender for subscription error lifecycle messages.
-    error_sender: Option<Sender<StdbSubscriptionErrorMessage<K>>>,
-}
-
-impl<K, M> Default for StdbSubscriptions<K, M>
-where
-    K: Eq + Hash + Clone + Send + Sync + 'static,
-    M: SpacetimeModule,
-    M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
-{
-    fn default() -> Self {
-        Self {
-            entries: HashMap::new(),
-            applied_sender: None,
-            error_sender: None,
-        }
-    }
+    error_sender: Sender<StdbSubscriptionErrorMessage<K>>,
 }
 
 impl<K, M> StdbSubscriptions<K, M>
@@ -171,22 +156,15 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
-        let Some(applied_sender) = self.applied_sender.clone() else {
-            return;
-        };
-        let Some(error_sender) = self.error_sender.clone() else {
-            return;
-        };
-
         for (key, entry) in self.entries.iter_mut() {
             if !entry.queued {
                 continue;
             }
 
             let applied_key = key.clone();
-            let applied_sender = applied_sender.clone();
+            let applied_sender = self.applied_sender.clone();
             let error_key = key.clone();
-            let error_sender = error_sender.clone();
+            let error_sender = self.error_sender.clone();
 
             let handle = conn
                 .subscription_builder()
@@ -265,17 +243,14 @@ where
         register_channel::<StdbSubscriptionErrorMessage<K>>(app);
 
         let world = app.world();
-        let applied_sender = channel_sender::<StdbSubscriptionAppliedMessage<K>>(world);
-        let error_sender = channel_sender::<StdbSubscriptionErrorMessage<K>>(world);
+        app.insert_resource(StdbSubscriptions::<K, M> {
+            entries: HashMap::default(),
+            applied_sender: channel_sender::<StdbSubscriptionAppliedMessage<K>>(world),
+            error_sender: channel_sender::<StdbSubscriptionErrorMessage<K>>(world),
+        });
 
-        app.init_resource::<StdbSubscriptions<K, M>>();
-
-        {
-            let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();
-            subs.applied_sender = Some(applied_sender);
-            subs.error_sender = Some(error_sender);
-            (self.initializer)(&mut subs);
-        }
+        let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();
+        (self.initializer)(&mut subs);
 
         app.add_systems(
             OnEnter(StdbConnectionState::Disconnected),

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -30,16 +30,6 @@ struct SubscriptionEntry<H> {
     queued: bool,
 }
 
-/// Stores senders for subscription lifecycle messages.
-#[derive(Resource)]
-struct SubscriptionMessageSenders<K>
-where
-    K: Clone + Send + Sync + 'static,
-{
-    applied: Sender<StdbSubscriptionAppliedMessage<K>>,
-    error: Sender<StdbSubscriptionErrorMessage<K>>,
-}
-
 /// SpacetimeDB subscription [`Resource`].
 ///
 /// Keeps subscription intent separate from active handles so queries can be
@@ -53,6 +43,10 @@ where
 {
     /// Subscription entries keyed by user-defined subscription key.
     entries: HashMap<K, SubscriptionEntry<M::SubscriptionHandle>>,
+    /// Sender for subscription applied lifecycle messages.
+    applied_sender: Option<Sender<StdbSubscriptionAppliedMessage<K>>>,
+    /// Sender for subscription error lifecycle messages.
+    error_sender: Option<Sender<StdbSubscriptionErrorMessage<K>>>,
 }
 
 impl<K, M> Default for StdbSubscriptions<K, M>
@@ -64,6 +58,8 @@ where
     fn default() -> Self {
         Self {
             entries: HashMap::new(),
+            applied_sender: None,
+            error_sender: None,
         }
     }
 }
@@ -165,17 +161,8 @@ where
         self.entries.values().any(|entry| entry.queued)
     }
 
-    /// Re-queues all active subscriptions for re-application after a disconnect.
-    fn queue_on_disconnect(&mut self) {
-        for entry in self.entries.values_mut() {
-            if entry.handle.take().is_some() {
-                entry.queued = true;
-            }
-        }
-    }
-
     /// Sends queued subscriptions to the active connection.
-    fn apply_queued<C>(&mut self, conn: &StdbConnection<C>, senders: &SubscriptionMessageSenders<K>)
+    fn apply_queued<C>(&mut self, conn: &StdbConnection<C>)
     where
         C: DbConnection<Module = M>
             + DbContext<SubscriptionBuilder = SubscriptionBuilder<M>>
@@ -184,15 +171,22 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
+        let Some(applied_sender) = self.applied_sender.clone() else {
+            return;
+        };
+        let Some(error_sender) = self.error_sender.clone() else {
+            return;
+        };
+
         for (key, entry) in self.entries.iter_mut() {
             if !entry.queued {
                 continue;
             }
 
             let applied_key = key.clone();
-            let applied_sender = senders.applied.clone();
+            let applied_sender = applied_sender.clone();
             let error_key = key.clone();
-            let error_sender = senders.error.clone();
+            let error_sender = error_sender.clone();
 
             let handle = conn
                 .subscription_builder()
@@ -271,17 +265,17 @@ where
         register_channel::<StdbSubscriptionErrorMessage<K>>(app);
 
         let world = app.world();
-        let senders = SubscriptionMessageSenders {
-            applied: channel_sender::<StdbSubscriptionAppliedMessage<K>>(world),
-            error: channel_sender::<StdbSubscriptionErrorMessage<K>>(world),
-        };
+        let applied_sender = channel_sender::<StdbSubscriptionAppliedMessage<K>>(world);
+        let error_sender = channel_sender::<StdbSubscriptionErrorMessage<K>>(world);
 
-        app.insert_resource(senders);
         app.init_resource::<StdbSubscriptions<K, M>>();
 
-        let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();
-        (self.initializer)(&mut subs);
-        drop(subs);
+        {
+            let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();
+            subs.applied_sender = Some(applied_sender);
+            subs.error_sender = Some(error_sender);
+            (self.initializer)(&mut subs);
+        }
 
         app.add_systems(
             OnEnter(StdbConnectionState::Disconnected),
@@ -316,13 +310,16 @@ where
     M: SpacetimeModule,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    subs.queue_on_disconnect();
+    for entry in subs.entries.values_mut() {
+        if entry.handle.take().is_some() {
+            entry.queued = true;
+        }
+    }
 }
 
 /// Sends queued subscriptions to the current connection.
 fn apply_queued_subscriptions<K, C, M>(
     conn: Res<StdbConnection<C>>,
-    senders: Res<SubscriptionMessageSenders<K>>,
     mut subs: ResMut<StdbSubscriptions<K, M>>,
 ) where
     K: Eq + Hash + Clone + Send + Sync + 'static,
@@ -334,5 +331,5 @@ fn apply_queued_subscriptions<K, C, M>(
     M: SpacetimeModule<DbConnection = C>,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    subs.apply_queued(&conn, &senders);
+    subs.apply_queued(&conn);
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -2,12 +2,14 @@
 //!
 //! Manages subscription intent and active handles via Bevy systems and resources.
 use crate::{
+    channel_bridge::{channel_sender, register_channel},
     connection::{StdbConnection, StdbConnectionState},
     set::StdbSet,
 };
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::prelude::{IntoScheduleConfigs, Res, ResMut, Resource};
 use bevy_state::prelude::{OnEnter, State};
+use crossbeam_channel::Sender;
 use spacetimedb_sdk::{
     __codegen::{__query_builder::Query, DbConnection, SpacetimeModule, SubscriptionBuilder},
     DbContext, Result as StdbResult, SubscriptionHandle as StdbSubscriptionHandle,
@@ -25,6 +27,27 @@ struct SubscriptionEntry<H> {
     sql: String,
     /// Whether this subscription should be applied on the next active connection.
     queued: bool,
+}
+
+/// Stores senders for subscription lifecycle messages.
+#[derive(Resource)]
+struct SubscriptionMessageSenders<K>
+where
+    K: Clone + Send + Sync + 'static,
+{
+    applied: Sender<crate::message::StdbSubscriptionAppliedMessage<K>>,
+    error: Sender<crate::message::StdbSubscriptionErrorMessage<K>>,
+}
+
+/// Configures a queued subscription registration.
+pub struct SubscriptionRegistration<'a, K, M>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    M: SpacetimeModule,
+    M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
+{
+    _key: K,
+    _subs: &'a mut StdbSubscriptions<K, M>,
 }
 
 /// SpacetimeDB subscription [`Resource`].
@@ -62,33 +85,50 @@ where
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
     /// Stores a typed query for `key` and queues it to be applied.
-    pub fn subscribe_query<T, Q>(&mut self, key: K, query: impl Fn(M::QueryBuilder) -> Q)
+    pub fn subscribe_query<T, Q>(
+        &mut self,
+        key: K,
+        query: impl Fn(M::QueryBuilder) -> Q,
+    ) -> SubscriptionRegistration<'_, K, M>
     where
         Q: Query<T>,
     {
         let res = query(M::QueryBuilder::default());
         let sql = Query::into_sql(res);
-        self.subscribe_sql(key, sql);
+        self.subscribe_sql(key, sql)
     }
 
     /// Stores a SQL query for `key` and queues it to be applied.
-    pub fn subscribe_sql(&mut self, key: K, sql: impl Into<String>) {
+    pub fn subscribe_sql(
+        &mut self,
+        key: K,
+        sql: impl Into<String>,
+    ) -> SubscriptionRegistration<'_, K, M> {
         let sql = sql.into();
 
         if let Some(entry) = self.entries.get_mut(&key) {
             entry.sql = sql;
             entry.queued = true;
-            return;
+
+            return SubscriptionRegistration {
+                _key: key,
+                _subs: self,
+            };
         }
 
         self.entries.insert(
-            key,
+            key.clone(),
             SubscriptionEntry {
                 handle: None,
                 sql,
                 queued: true,
             },
         );
+
+        SubscriptionRegistration {
+            _key: key,
+            _subs: self,
+        }
     }
 
     /// Unsubscribes `key` and removes its stored query.
@@ -152,8 +192,17 @@ where
         self.entries.values().any(|entry| entry.queued)
     }
 
+    /// Re-queues all active subscriptions for re-application after a disconnect.
+    fn queue_on_disconnect(&mut self) {
+        for entry in self.entries.values_mut() {
+            if entry.handle.take().is_some() {
+                entry.queued = true;
+            }
+        }
+    }
+
     /// Sends queued subscriptions to the active connection.
-    fn apply_queued<C>(&mut self, conn: &StdbConnection<C>)
+    fn apply_queued<C>(&mut self, conn: &StdbConnection<C>, senders: &SubscriptionMessageSenders<K>)
     where
         C: DbConnection<Module = M>
             + DbContext<SubscriptionBuilder = SubscriptionBuilder<M>>
@@ -162,15 +211,34 @@ where
             + 'static,
         M: SpacetimeModule<DbConnection = C>,
     {
-        for entry in self.entries.values_mut() {
+        for (key, entry) in self.entries.iter_mut() {
             if !entry.queued {
                 continue;
             }
 
-            let handle = conn.subscription_builder().subscribe(entry.sql.as_str());
+            let applied_key = key.clone();
+            let applied_sender = senders.applied.clone();
+            let error_key = key.clone();
+            let error_sender = senders.error.clone();
+
+            let handle = conn
+                .subscription_builder()
+                .on_applied(move |_ctx| {
+                    let _ = applied_sender
+                        .send(crate::message::StdbSubscriptionAppliedMessage { key: applied_key });
+                })
+                .on_error(move |_ctx, err| {
+                    let _ = error_sender.send(crate::message::StdbSubscriptionErrorMessage {
+                        key: error_key,
+                        err,
+                    });
+                })
+                .subscribe(entry.sql.as_str());
+
             if let Some(old_handle) = entry.handle.replace(handle) {
                 let _ = old_handle.unsubscribe();
             }
+
             entry.queued = false;
         }
     }
@@ -215,7 +283,7 @@ where
 
 impl<K, C, M> Plugin for SubscriptionsPlugin<K, C, M>
 where
-    K: Eq + Hash + Clone + Send + Sync + 'static,
+    K: Eq + Hash + Clone + PartialEq + Send + Sync + 'static,
     C: DbConnection<Module = M>
         + DbContext<SubscriptionBuilder = SubscriptionBuilder<M>>
         + Send
@@ -226,9 +294,21 @@ where
 {
     /// Installs the subscription resource and lifecycle systems.
     fn build(&self, app: &mut App) {
+        register_channel::<crate::message::StdbSubscriptionAppliedMessage<K>>(app);
+        register_channel::<crate::message::StdbSubscriptionErrorMessage<K>>(app);
+
+        let world = app.world();
+        let senders = SubscriptionMessageSenders {
+            applied: channel_sender::<crate::message::StdbSubscriptionAppliedMessage<K>>(world),
+            error: channel_sender::<crate::message::StdbSubscriptionErrorMessage<K>>(world),
+        };
+
+        app.insert_resource(senders);
         app.init_resource::<StdbSubscriptions<K, M>>();
+
         let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();
         (self.initializer)(&mut subs);
+        drop(subs);
 
         app.add_systems(
             OnEnter(StdbConnectionState::Disconnected),
@@ -263,16 +343,13 @@ where
     M: SpacetimeModule,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    for entry in subs.entries.values_mut() {
-        if entry.handle.take().is_some() {
-            entry.queued = true;
-        }
-    }
+    subs.queue_on_disconnect();
 }
 
 /// Sends queued subscriptions to the current connection.
 fn apply_queued_subscriptions<K, C, M>(
     conn: Res<StdbConnection<C>>,
+    senders: Res<SubscriptionMessageSenders<K>>,
     mut subs: ResMut<StdbSubscriptions<K, M>>,
 ) where
     K: Eq + Hash + Clone + Send + Sync + 'static,
@@ -284,5 +361,5 @@ fn apply_queued_subscriptions<K, C, M>(
     M: SpacetimeModule<DbConnection = C>,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    subs.apply_queued(&conn);
+    subs.apply_queued(&conn, &senders);
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -4,7 +4,7 @@
 use crate::{
     channel_bridge::{channel_sender, register_channel},
     connection::{StdbConnection, StdbConnectionState},
-    message::{StdbSubscriptionAppliedMessage, StdbSubscriptionErrorMessage},
+    message::{StdbSubAppliedMessage, StdbSubErrorMessage},
     set::StdbSet,
 };
 use bevy_app::{App, Plugin, PreUpdate};
@@ -44,9 +44,9 @@ where
     /// Subscription entries keyed by user-defined subscription key.
     entries: HashMap<K, SubscriptionEntry<M::SubscriptionHandle>>,
     /// Sender for subscription applied lifecycle messages.
-    applied_sender: Sender<StdbSubscriptionAppliedMessage<K>>,
+    applied_sender: Sender<StdbSubAppliedMessage<K>>,
     /// Sender for subscription error lifecycle messages.
-    error_sender: Sender<StdbSubscriptionErrorMessage<K>>,
+    error_sender: Sender<StdbSubErrorMessage<K>>,
 }
 
 impl<K, M> StdbSubscriptions<K, M>
@@ -169,11 +169,10 @@ where
             let handle = conn
                 .subscription_builder()
                 .on_applied(move |_ctx| {
-                    let _ =
-                        applied_sender.send(StdbSubscriptionAppliedMessage { key: applied_key });
+                    let _ = applied_sender.send(StdbSubAppliedMessage { key: applied_key });
                 })
                 .on_error(move |_ctx, err| {
-                    let _ = error_sender.send(StdbSubscriptionErrorMessage {
+                    let _ = error_sender.send(StdbSubErrorMessage {
                         key: error_key,
                         err,
                     });
@@ -239,14 +238,14 @@ where
 {
     /// Installs the subscription resource and lifecycle systems.
     fn build(&self, app: &mut App) {
-        register_channel::<StdbSubscriptionAppliedMessage<K>>(app);
-        register_channel::<StdbSubscriptionErrorMessage<K>>(app);
+        register_channel::<StdbSubAppliedMessage<K>>(app);
+        register_channel::<StdbSubErrorMessage<K>>(app);
 
         let world = app.world();
         app.insert_resource(StdbSubscriptions::<K, M> {
             entries: HashMap::default(),
-            applied_sender: channel_sender::<StdbSubscriptionAppliedMessage<K>>(world),
-            error_sender: channel_sender::<StdbSubscriptionErrorMessage<K>>(world),
+            applied_sender: channel_sender::<StdbSubAppliedMessage<K>>(world),
+            error_sender: channel_sender::<StdbSubErrorMessage<K>>(world),
         });
 
         let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();


### PR DESCRIPTION
Adds messages for the `on_applied` and `on_error` callbacks exposed in the spacetimedb `subscription_builder()` method.

I tried to store callbacks but it is actually not as useful because of lifetime issues when trying to use system params inside of the callback. Messages just mapped more cleanly.


## Usage
```rust
#[derive(Clone, Eq, Hash, PartialEq, Debug)]
pub enum SubKey {
    MyCharacters,
}

fn on_applied(
  mut applied_msgs: ReadStdbSubscriptionAppliedMessage<SubKey>,
  conn: Res<StdbConn>,
) {
  for message in applied_messages.read() {
    if message.is(&SubKey::MyCharacters) {
      // We now know that the subscription was just applied so accessing the client cache
      // is effectively the same thing as doing it in the on_applied callback
      println!("You have {} characters.", conn.db().my_characters().count());
    }
  }
}
```