### PR TITLE
chore: remove subscription initializer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,10 @@
 //!                 .with_uri("http://localhost:3000")
 //!                 .with_background_driver(DbConnection::run_threaded)
 //!                 .with_reconnect(StdbReconnectOptions::default())
-//!                 .add_systems(Update, subscribe_players_on_connect)
+//!                 .with_subscriptions::<SubKey>()
 //!                 .add_table::<PlayerRow>(|reg, db| reg.bind(db.player()))
 //!         )
+//!         .add_systems(Update, subscribe_players_on_connect)
 //!         .add_systems(Update, on_player_insert)
 //!         .run();
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,7 @@
 //!                 .with_subscriptions::<SubKey>()
 //!                 .add_table::<PlayerRow>(|reg, db| reg.bind(db.player()))
 //!         )
-//!         .add_systems(Update, subscribe_players_on_connect)
-//!         .add_systems(Update, on_player_insert)
+//!         .add_systems(Update, (on_player_insert, subscribe_players_on_connect))
 //!         .run();
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,20 @@
 //!                 .with_uri("http://localhost:3000")
 //!                 .with_background_driver(DbConnection::run_threaded)
 //!                 .with_reconnect(StdbReconnectOptions::default())
-//!                 .with_subscriptions(|subs: &mut StdbSubscriptions<SubKey, RemoteModule>| {
-//!                     subs.subscribe_sql(SubKey::Players, "SELECT * FROM player");
-//!                 })
+//!                 .add_systems(Update, subscribe_players_on_connect)
 //!                 .add_table::<PlayerRow>(|reg, db| reg.bind(db.player()))
 //!         )
 //!         .add_systems(Update, on_player_insert)
 //!         .run();
+//! }
+//!
+//! fn subscribe_players_on_connect(
+//!     mut connected: ReadStdbConnectedMessage,
+//!     mut subs: ResMut<StdbSubscriptions<SubKey, RemoteModule>>,
+//! ) {
+//!     if connected.read().next().is_some() {
+//!         subs.subscribe_sql(SubKey::Players, "SELECT * FROM player");
+//!     }
 //! }
 //!
 //! fn on_player_insert(mut msgs: ReadInsertMessage<PlayerRow>) {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -328,7 +328,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Enables the subscription subsystem.
     ///
-    /// Additional subscriptions can be queued at runtime from normal Bevy
+    /// Subscriptions can be queued at runtime from normal Bevy
     /// systems by accessing [`StdbSubscriptions`] as a resource.
     ///
     /// # Example
@@ -336,9 +336,6 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     /// ```ignore
     /// .with_subscriptions::<SubKey>()
     /// ```
-    ///
-    /// The consumer can then queue subscriptions from systems, such as after
-    /// receiving [`ReadStdbConnectedMessage`](crate::prelude::ReadStdbConnectedMessage).
     ///
     /// # Panics
     ///

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -329,7 +329,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     /// Enables the subscription subsystem.
     ///
     /// Subscriptions can be queued at runtime from normal Bevy
-    /// systems by accessing [`StdbSubscriptions`] as a resource.
+    /// systems by accessing [`crate::subscription::StdbSubscriptions`] as a resource.
     ///
     /// # Example
     ///

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use crate::{
     connection::{ConnectionDriver, StdbConnectionPlugin},
     reconnect::{ReconnectPlugin, StdbReconnectOptions},
     set::StdbSet,
-    subscription::SubscriptionsPlugin,
+    subscription::{SubscriptionsInitializer, SubscriptionsPlugin},
     table::{
         EventTableBinder, TableBindCallback, TableBinder, TableRegistrationCallback,
         TableWithoutPkBinder, ViewBinder, register_event_table, register_table,
@@ -60,7 +60,7 @@ pub struct StdbPlugin<
     driver: Option<ConnectionDriver<C>>,
     reconnect_options: Option<StdbReconnectOptions>,
     delayed_connection: bool,
-    subscriptions_initializer: Option<Arc<dyn Fn(&mut App) + Send + Sync>>,
+    subscriptions_initializer: Option<Arc<SubscriptionsInitializer>>,
     table_registrations: Vec<Arc<TableRegistrationCallback>>,
     table_bindings: Vec<Arc<TableBindCallback<C>>>,
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -481,8 +481,8 @@ impl<
             app.add_plugins(ReconnectPlugin::<C, M>::new(reconnect_options));
         }
 
-        if let Some(add_subscriptions_plugin) = self.subscriptions_initializer.clone() {
-            add_subscriptions_plugin(app);
+        if let Some(init) = self.subscriptions_initializer.clone() {
+            init(app);
         }
 
         for register in &self.table_registrations {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use crate::{
     connection::{ConnectionDriver, StdbConnectionPlugin},
     reconnect::{ReconnectPlugin, StdbReconnectOptions},
     set::StdbSet,
-    subscription::{StdbSubscriptions, SubscriptionsInitializer, SubscriptionsPlugin},
+    subscription::SubscriptionsPlugin,
     table::{
         EventTableBinder, TableBindCallback, TableBinder, TableRegistrationCallback,
         TableWithoutPkBinder, ViewBinder, register_event_table, register_table,
@@ -30,11 +30,19 @@ use std::{hash::Hash, sync::Arc};
 ///         .with_uri("http://localhost:3000")
 ///         .with_background_driver(DbConnection::run_threaded)
 ///         .with_reconnect(StdbReconnectOptions::default())
-///         .with_subscriptions(|subs: &mut StdbSubscriptions<SubKey, Module>| {
-///             subs.subscribe_sql(SubKey::Chat, "SELECT * FROM chat_message");
-///         })
+///         .with_subscriptions::<SubKey>()
 ///         .add_table::<ChatMessageRow>(|reg, db| reg.bind(db.chat_message()))
-/// );
+/// )
+/// .add_systems(Update, subscribe_on_connected);
+///
+/// fn subscribe_on_connected(
+///     mut connected: ReadStdbConnectedMessage,
+///     mut subs: ResMut<StdbSubscriptions<SubKey, Module>>,
+/// ) {
+///     if connected.read().next().is_some() {
+///         subs.subscribe_sql(SubKey::Chat, "SELECT * FROM chat_message");
+///     }
+/// }
 /// ```
 ///
 /// # Panics
@@ -52,7 +60,7 @@ pub struct StdbPlugin<
     driver: Option<ConnectionDriver<C>>,
     reconnect_options: Option<StdbReconnectOptions>,
     delayed_connection: bool,
-    subscriptions_initializer: Option<Arc<SubscriptionsInitializer>>,
+    subscriptions_plugin: Option<Arc<dyn Fn(&mut App) + Send + Sync>>,
     table_registrations: Vec<Arc<TableRegistrationCallback>>,
     table_bindings: Vec<Arc<TableBindCallback<C>>>,
 }
@@ -69,7 +77,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             driver: None,
             reconnect_options: None,
             delayed_connection: false,
-            subscriptions_initializer: None,
+            subscriptions_plugin: None,
             table_registrations: Vec::new(),
             table_bindings: Vec::new(),
         }
@@ -320,30 +328,22 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
 
     /// Enables the subscription subsystem.
     ///
-    /// The initializer runs during plugin build and populates the
-    /// [`StdbSubscriptions`] resource with queries that should be managed
-    /// automatically. Queued subscriptions are applied when connected and
-    /// re-applied after reconnects.
+    /// Additional subscriptions can be queued at runtime from normal Bevy
+    /// systems by accessing [`StdbSubscriptions`] as a resource.
     ///
     /// # Example
     ///
     /// ```ignore
-    /// .with_subscriptions(|subs: &mut StdbSubscriptions<SubKey, RemoteModule>| {
-    ///     subs.subscribe_sql(SubKey::Players, "SELECT * FROM player");
-    ///     subs.subscribe_query(SubKey::Chat, |q| q.from.chat_message());
-    /// })
+    /// .with_subscriptions::<SubKey>()
     /// ```
     ///
-    /// Additional subscriptions can be queued at runtime from normal Bevy
-    /// systems by accessing [`StdbSubscriptions`] as a resource.
+    /// The consumer can then queue subscriptions from systems, such as after
+    /// receiving [`ReadStdbConnectedMessage`](crate::prelude::ReadStdbConnectedMessage).
     ///
     /// # Panics
     ///
     /// Panics if called more than once.
-    pub fn with_subscriptions<K>(
-        mut self,
-        init: impl Fn(&mut StdbSubscriptions<K, M>) + Send + Sync + 'static,
-    ) -> Self
+    pub fn with_subscriptions<K>(mut self) -> Self
     where
         K: Eq + Hash + Clone + Send + Sync + 'static,
         M::SubscriptionHandle: SubscriptionHandle + Send + Sync + 'static,
@@ -354,16 +354,12 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             + 'static,
     {
         assert!(
-            self.subscriptions_initializer.is_none(),
+            self.subscriptions_plugin.is_none(),
             "`with_subscriptions()` may only be called once"
         );
 
-        let init = Arc::new(init);
-        self.subscriptions_initializer = Some(Arc::new(move |app: &mut App| {
-            let init = init.clone();
-            app.add_plugins(SubscriptionsPlugin::<K, C, M>::new(move |subs| {
-                init(subs);
-            }));
+        self.subscriptions_plugin = Some(Arc::new(|app: &mut App| {
+            app.add_plugins(SubscriptionsPlugin::<K, C, M>::default());
         }));
 
         self
@@ -485,8 +481,8 @@ impl<
             app.add_plugins(ReconnectPlugin::<C, M>::new(reconnect_options));
         }
 
-        if let Some(init) = self.subscriptions_initializer.clone() {
-            init(app);
+        if let Some(add_subscriptions_plugin) = self.subscriptions_plugin.clone() {
+            add_subscriptions_plugin(app);
         }
 
         for register in &self.table_registrations {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -60,7 +60,7 @@ pub struct StdbPlugin<
     driver: Option<ConnectionDriver<C>>,
     reconnect_options: Option<StdbReconnectOptions>,
     delayed_connection: bool,
-    subscriptions_plugin: Option<Arc<dyn Fn(&mut App) + Send + Sync>>,
+    subscriptions_initializer: Option<Arc<dyn Fn(&mut App) + Send + Sync>>,
     table_registrations: Vec<Arc<TableRegistrationCallback>>,
     table_bindings: Vec<Arc<TableBindCallback<C>>>,
 }
@@ -77,7 +77,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             driver: None,
             reconnect_options: None,
             delayed_connection: false,
-            subscriptions_plugin: None,
+            subscriptions_initializer: None,
             table_registrations: Vec::new(),
             table_bindings: Vec::new(),
         }
@@ -354,11 +354,11 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
             + 'static,
     {
         assert!(
-            self.subscriptions_plugin.is_none(),
+            self.subscriptions_initializer.is_none(),
             "`with_subscriptions()` may only be called once"
         );
 
-        self.subscriptions_plugin = Some(Arc::new(|app: &mut App| {
+        self.subscriptions_initializer = Some(Arc::new(|app: &mut App| {
             app.add_plugins(SubscriptionsPlugin::<K, C, M>::default());
         }));
 
@@ -481,7 +481,7 @@ impl<
             app.add_plugins(ReconnectPlugin::<C, M>::new(reconnect_options));
         }
 
-        if let Some(add_subscriptions_plugin) = self.subscriptions_plugin.clone() {
+        if let Some(add_subscriptions_plugin) = self.subscriptions_initializer.clone() {
             add_subscriptions_plugin(app);
         }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -17,6 +17,8 @@ use spacetimedb_sdk::{
 };
 use std::{collections::HashMap, hash::Hash, marker::PhantomData};
 
+pub(crate) type SubscriptionsInitializer = dyn Fn(&mut App) + Send + Sync;
+
 /// Stored subscription intent and active handle for a single key.
 struct SubscriptionEntry<H> {
     /// Active handle for the current connection, if any.

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -17,9 +17,6 @@ use spacetimedb_sdk::{
 };
 use std::{collections::HashMap, hash::Hash, marker::PhantomData};
 
-pub(crate) type SubscriptionsInitializer = dyn Fn(&mut App) + Send + Sync;
-type SubscriptionStateInitializer<K, M> = dyn Fn(&mut StdbSubscriptions<K, M>) + Send + Sync;
-
 /// Stored subscription intent and active handle for a single key.
 struct SubscriptionEntry<H> {
     /// Active handle for the current connection, if any.
@@ -197,11 +194,10 @@ where
     M: SpacetimeModule<DbConnection = C>,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    initializer: Box<SubscriptionStateInitializer<K, M>>,
-    _marker: PhantomData<(C, M)>,
+    _marker: PhantomData<(K, C, M)>,
 }
 
-impl<K, C, M> SubscriptionsPlugin<K, C, M>
+impl<K, C, M> Default for SubscriptionsPlugin<K, C, M>
 where
     K: Eq + Hash + Clone + Send + Sync + 'static,
     C: DbConnection<Module = M>
@@ -212,11 +208,8 @@ where
     M: SpacetimeModule<DbConnection = C>,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    pub(crate) fn new(
-        initializer: impl Fn(&mut StdbSubscriptions<K, M>) + Send + Sync + 'static,
-    ) -> Self {
+    fn default() -> Self {
         Self {
-            initializer: Box::new(initializer),
             _marker: PhantomData,
         }
     }
@@ -244,9 +237,6 @@ where
             applied_sender: channel_sender::<StdbSubscriptionAppliedMessage<K>>(world),
             error_sender: channel_sender::<StdbSubscriptionErrorMessage<K>>(world),
         });
-
-        let mut subs = app.world_mut().resource_mut::<StdbSubscriptions<K, M>>();
-        (self.initializer)(&mut subs);
 
         app.add_systems(
             OnEnter(StdbConnectionState::Disconnected),


### PR DESCRIPTION
Its not really that useful in a real world application. There are some global subs that could exist on connect but that can just simply added via reading ReadStdbConnectedMessage in a system 