### PR TITLE
chore: faster subscription run condition check

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -263,7 +263,7 @@ where
     M: SpacetimeModule,
     M::SubscriptionHandle: StdbSubscriptionHandle + Send + Sync + 'static,
 {
-    subs.has_queued() && *state.get() == StdbConnectionState::Connected
+    *state.get() == StdbConnectionState::Connected && subs.has_queued()
 }
 
 /// Re-queues all active subscriptions for re-application after a disconnect.


### PR DESCRIPTION
The state check is faster so may as well check that first