### PR TITLE
feat: add event information to table messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_stdb"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bevy_app",
  "bevy_ecs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_stdb"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.93"
 description = "A Bevy-native integration for SpacetimeDB with table messages, subscriptions, and reconnect support."

--- a/README.md
+++ b/README.md
@@ -187,7 +187,25 @@ Depending on the table shape, `bevy_stdb` forwards updates into Bevy messages su
 - `UpdateMessage<T>`
 - `InsertUpdateMessage<T>`
 
-This lets normal Bevy systems react to database changes using message readers.
+This lets normal Bevy systems react to database changes using message readers. These messages include both the affected row data and the SpacetimeDB event that triggered the change.
+
+```rust
+use crate::module_bindings::Reducer;
+use bevy_stdb::prelude::*;
+use spacetimedb_sdk::Event;
+
+fn on_person_insert(mut messages: ReadInsertMessage<PersonRow>) {
+  for msg in messages.read() {
+    match &msg.event {
+      Event::Reducer(r) => {
+        /* r.status, r.timestamp, r.reducer */ 
+        if let Reducer::CreatePerson(p) = &r.reducer { /* ... */ }
+      },
+      _ => ={ /* ... */ }
+    }
+  }
+}
+```
 
 ## Subscriptions
 
@@ -287,13 +305,19 @@ fn connect_after_delay(
 
 Use `connect_with_token(...)` instead when you want to supply a token at runtime.
 
+### Connection-dependent resources
+
+`bevy_stdb` resources are only available while a connection is active. Systems that access those resources should either be guarded with a run condition such as `resource_exists::<StdbConnection<_>>()`, or accept them as optional system parameters.
+
+This avoids runtime failures when a system runs before the connection has been established or after it has been lost.
+
 
 ## Compatibility
 
 | bevy_stdb | bevy   | spacetimedb_sdk |
 | --------- | ------ | --------------- |
 | 0.1 - 0.2 | 0.18   | 2.0             |
-| 0.3 - 0.6 | 0.18   | 2.1             |
+| 0.3 - 0.7 | 0.18   | 2.1             |
 
 ## Notes
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,13 @@
 //! Bevy message types for SpacetimeDB connection, subscription, and table events.
 use bevy_ecs::prelude::Message;
-use spacetimedb_sdk::{Error, Identity};
+use spacetimedb_sdk::{
+    __codegen::{AbstractEventContext, InModule, SpacetimeModule},
+    Error, Identity,
+};
+
+/// Event metadata associated with row callbacks for a SpacetimeDB row type.
+pub type RowEvent<T> =
+    <<<T as InModule>::Module as SpacetimeModule>::EventContext as AbstractEventContext>::Event;
 
 /// A [`Message`] sent when a SpacetimeDB connection is established.
 #[derive(Message, Debug)]
@@ -57,21 +64,39 @@ impl<K: PartialEq> StdbSubscriptionErrorMessage<K> {
 
 /// A [`Message`] sent when a row is inserted into a subscribed table.
 #[derive(Message, Debug)]
-pub struct InsertMessage<T> {
+pub struct InsertMessage<T>
+where
+    T: InModule,
+    RowEvent<T>: Send + Sync,
+{
+    /// The SpacetimeDB event that triggered the row callback.
+    pub event: RowEvent<T>,
     /// The affected row.
     pub row: T,
 }
 
 /// A [`Message`] sent when a row is deleted from a subscribed table.
 #[derive(Message, Debug)]
-pub struct DeleteMessage<T> {
+pub struct DeleteMessage<T>
+where
+    T: InModule,
+    RowEvent<T>: Send + Sync,
+{
+    /// The SpacetimeDB event that triggered the row callback.
+    pub event: RowEvent<T>,
     /// The affected row.
     pub row: T,
 }
 
 /// A [`Message`] sent when a row in a subscribed table is updated.
 #[derive(Message, Debug)]
-pub struct UpdateMessage<T> {
+pub struct UpdateMessage<T>
+where
+    T: InModule,
+    RowEvent<T>: Send + Sync,
+{
+    /// The SpacetimeDB event that triggered the row callback.
+    pub event: RowEvent<T>,
     /// The previous row value.
     pub old: T,
     /// The updated row value.
@@ -80,7 +105,13 @@ pub struct UpdateMessage<T> {
 
 /// A [`Message`] sent when a row in a subscribed table is inserted or updated.
 #[derive(Message, Debug)]
-pub struct InsertUpdateMessage<T> {
+pub struct InsertUpdateMessage<T>
+where
+    T: InModule,
+    RowEvent<T>: Send + Sync,
+{
+    /// The SpacetimeDB event that triggered the row callback.
+    pub event: RowEvent<T>,
     /// The previous row value, if this was an update.
     pub old: Option<T>,
     /// The current row value.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -244,7 +244,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(TableBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + 'static,
+        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_table::<TRow>));
@@ -269,7 +270,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(TableWithoutPkBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + 'static,
+        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_table_without_pk::<TRow>));
@@ -292,7 +294,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(ViewBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + 'static,
+        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_view::<TRow>));
@@ -315,7 +318,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(EventTableBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + 'static,
+        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_event_table::<TRow>));

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,7 +15,7 @@ use bevy_app::{App, Plugin, PreStartup, PreUpdate};
 use bevy_ecs::prelude::IntoScheduleConfigs;
 use bevy_state::app::StatesPlugin;
 use spacetimedb_sdk::{
-    __codegen::{DbConnection, InModule, SpacetimeModule},
+    __codegen::{DbConnection, InModule, SpacetimeModule, SubscriptionBuilder},
     Compression, DbContext, SubscriptionHandle,
 };
 use std::{hash::Hash, sync::Arc};
@@ -245,7 +245,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(TableBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
+        TRow: Send + Sync + Clone + InModule + 'static,
         RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
@@ -352,7 +352,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         K: Eq + Hash + Clone + Send + Sync + 'static,
         M::SubscriptionHandle: SubscriptionHandle + Send + Sync + 'static,
         C: DbConnection<Module = M>
-            + DbContext<SubscriptionBuilder = spacetimedb_sdk::__codegen::SubscriptionBuilder<M>>
+            + DbContext<SubscriptionBuilder = SubscriptionBuilder<M>>
             + Send
             + Sync
             + 'static,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,7 @@
 use crate::{
     channel_bridge::ChannelBridgePlugin,
     connection::{ConnectionDriver, StdbConnectionPlugin},
+    message::RowEvent,
     reconnect::{ReconnectPlugin, StdbReconnectOptions},
     set::StdbSet,
     subscription::{SubscriptionsInitializer, SubscriptionsPlugin},
@@ -14,7 +15,7 @@ use bevy_app::{App, Plugin, PreStartup, PreUpdate};
 use bevy_ecs::prelude::IntoScheduleConfigs;
 use bevy_state::app::StatesPlugin;
 use spacetimedb_sdk::{
-    __codegen::{DbConnection, SpacetimeModule},
+    __codegen::{DbConnection, InModule, SpacetimeModule},
     Compression, DbContext, SubscriptionHandle,
 };
 use std::{hash::Hash, sync::Arc};
@@ -245,7 +246,7 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     ) -> Self
     where
         TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_table::<TRow>));
@@ -270,8 +271,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(TableWithoutPkBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_table_without_pk::<TRow>));
@@ -294,8 +295,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(ViewBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_view::<TRow>));
@@ -318,8 +319,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
         bind: impl for<'db> Fn(EventTableBinder<'_, TRow>, &'db C::DbView) + Send + Sync + 'static,
     ) -> Self
     where
-        TRow: Send + Sync + Clone + spacetimedb_sdk::__codegen::InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        RowEvent<TRow>: Send + Sync,
     {
         self.table_registrations
             .push(Arc::new(register_event_table::<TRow>));

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 use bevy_app::App;
 use bevy_ecs::prelude::World;
-use spacetimedb_sdk::{EventTable, Table, TableWithPrimaryKey};
+use spacetimedb_sdk::{
+    __codegen::{AbstractEventContext, InModule},
+    EventTable, Table, TableWithPrimaryKey,
+};
 use std::marker::PhantomData;
 
 /// Stored callback that performs one-time Bevy app registration for a table/view.
@@ -44,8 +47,10 @@ impl<'w, TRow> TableBinder<'w, TRow> {
     /// Bevy messages.
     pub fn bind<TTable>(self, table: TTable)
     where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
+        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
+            + TableWithPrimaryKey<Row = TRow>,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
         bind_delete::<TRow, TTable>(self.world, &table);
@@ -75,8 +80,9 @@ impl<'w, TRow> TableWithoutPkBinder<'w, TRow> {
     /// Bevy messages.
     pub fn bind<TTable>(self, table: TTable)
     where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
+        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
         bind_delete::<TRow, TTable>(self.world, &table);
@@ -104,8 +110,9 @@ impl<'w, TRow> ViewBinder<'w, TRow> {
     /// Bevy messages.
     pub fn bind<TTable>(self, table: TTable)
     where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow>,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
+        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
         bind_delete::<TRow, TTable>(self.world, &table);
@@ -133,8 +140,10 @@ impl<'w, TRow> EventTableBinder<'w, TRow> {
     /// Bevy messages.
     pub fn bind<TTable>(self, table: TTable)
     where
-        TRow: Send + Sync + Clone + 'static,
-        TTable: Table<Row = TRow> + EventTable,
+        TRow: Send + Sync + Clone + InModule + 'static,
+        crate::message::RowEvent<TRow>: Send + Sync,
+        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
+            + EventTable,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
     }
@@ -143,7 +152,8 @@ impl<'w, TRow> EventTableBinder<'w, TRow> {
 /// Registers Bevy message channels for a table with a primary key.
 pub(crate) fn register_table<TRow>(app: &mut App)
 where
-    TRow: Send + Sync + Clone + 'static,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
 {
     register_channel::<InsertMessage<TRow>>(app);
     register_channel::<DeleteMessage<TRow>>(app);
@@ -154,7 +164,8 @@ where
 /// Registers Bevy message channels for a table without a primary key.
 pub(crate) fn register_table_without_pk<TRow>(app: &mut App)
 where
-    TRow: Send + Sync + Clone + 'static,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
 {
     register_channel::<InsertMessage<TRow>>(app);
     register_channel::<DeleteMessage<TRow>>(app);
@@ -163,7 +174,8 @@ where
 /// Registers Bevy message channels for a view.
 pub(crate) fn register_view<TRow>(app: &mut App)
 where
-    TRow: Send + Sync + Clone + 'static,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
 {
     register_table_without_pk::<TRow>(app);
 }
@@ -171,41 +183,56 @@ where
 /// Registers Bevy message channels for an event table.
 pub(crate) fn register_event_table<TRow>(app: &mut App)
 where
-    TRow: Send + Sync + Clone + 'static,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
 {
     register_channel::<InsertMessage<TRow>>(app);
 }
 
 fn bind_insert<TRow, TTable>(world: &World, table: &TTable)
 where
-    TRow: Send + Sync + Clone + 'static,
-    TTable: Table<Row = TRow>,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
+    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
+    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender = channel_sender::<InsertMessage<TRow>>(world);
-    table.on_insert(move |_ctx, row| {
-        let _ = sender.send(InsertMessage { row: row.clone() });
+    table.on_insert(move |ctx, row| {
+        let _ = sender.send(InsertMessage {
+            event: ctx.event().clone(),
+            row: row.clone(),
+        });
     });
 }
 
 fn bind_delete<TRow, TTable>(world: &World, table: &TTable)
 where
-    TRow: Send + Sync + Clone + 'static,
-    TTable: Table<Row = TRow>,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
+    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
+    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender = channel_sender::<DeleteMessage<TRow>>(world);
-    table.on_delete(move |_ctx, row| {
-        let _ = sender.send(DeleteMessage { row: row.clone() });
+    table.on_delete(move |ctx, row| {
+        let _ = sender.send(DeleteMessage {
+            event: ctx.event().clone(),
+            row: row.clone(),
+        });
     });
 }
 
 fn bind_update<TRow, TTable>(world: &World, table: &TTable)
 where
-    TRow: Send + Sync + Clone + 'static,
-    TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
+    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
+        + TableWithPrimaryKey<Row = TRow>,
+    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender = channel_sender::<UpdateMessage<TRow>>(world);
-    table.on_update(move |_ctx, old, new| {
+    table.on_update(move |ctx, old, new| {
         let _ = sender.send(UpdateMessage {
+            event: ctx.event().clone(),
             old: old.clone(),
             new: new.clone(),
         });
@@ -214,20 +241,25 @@ where
 
 fn bind_insert_update<TRow, TTable>(world: &World, table: &TTable)
 where
-    TRow: Send + Sync + Clone + 'static,
-    TTable: Table<Row = TRow> + TableWithPrimaryKey<Row = TRow>,
+    TRow: Send + Sync + Clone + InModule + 'static,
+    crate::message::RowEvent<TRow>: Send + Sync,
+    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
+        + TableWithPrimaryKey<Row = TRow>,
+    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender_insert = channel_sender::<InsertUpdateMessage<TRow>>(world);
-    table.on_insert(move |_ctx, row| {
+    table.on_insert(move |ctx, row| {
         let _ = sender_insert.send(InsertUpdateMessage {
+            event: ctx.event().clone(),
             old: None,
             new: row.clone(),
         });
     });
 
     let sender_update = channel_sender::<InsertUpdateMessage<TRow>>(world);
-    table.on_update(move |_ctx, old, new| {
+    table.on_update(move |ctx, old, new| {
         let _ = sender_update.send(InsertUpdateMessage {
+            event: ctx.event().clone(),
             old: Some(old.clone()),
             new: new.clone(),
         });

--- a/src/table.rs
+++ b/src/table.rs
@@ -12,7 +12,7 @@ use crate::{
 use bevy_app::App;
 use bevy_ecs::prelude::World;
 use spacetimedb_sdk::{
-    __codegen::{AbstractEventContext, InModule, SpacetimeModule},
+    __codegen::{AbstractEventContext, DbContext, InModule, SpacetimeModule},
     EventTable, Table, TableWithPrimaryKey,
 };
 use std::marker::PhantomData;
@@ -21,9 +21,8 @@ use std::marker::PhantomData;
 pub(crate) type TableRegistrationCallback = dyn Fn(&mut App) + Send + Sync;
 
 /// Stored callback that binds SpacetimeDB table listeners for a concrete database view.
-pub(crate) type TableBindCallback<C> = dyn for<'db> Fn(&World, &'db <C as spacetimedb_sdk::__codegen::DbContext>::DbView)
-    + Send
-    + Sync;
+pub(crate) type TableBindCallback<C> =
+    dyn for<'db> Fn(&World, &'db <C as DbContext>::DbView) + Send + Sync;
 
 /// Binds callbacks for a table with a primary key.
 ///

--- a/src/table.rs
+++ b/src/table.rs
@@ -7,7 +7,7 @@
 //! [`InsertUpdateMessage`](crate::message::InsertUpdateMessage).
 use crate::{
     channel_bridge::{channel_sender, register_channel},
-    message::{DeleteMessage, InsertMessage, InsertUpdateMessage, UpdateMessage},
+    message::{DeleteMessage, InsertMessage, InsertUpdateMessage, RowEvent, UpdateMessage},
 };
 use bevy_app::App;
 use bevy_ecs::prelude::World;
@@ -47,7 +47,7 @@ impl<'w, TRow> TableBinder<'w, TRow> {
     pub fn bind<TTable>(self, table: TTable)
     where
         TRow: Send + Sync + Clone + InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        RowEvent<TRow>: Send + Sync,
         TTable: Table<
                 Row = TRow,
                 EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
@@ -82,7 +82,7 @@ impl<'w, TRow> TableWithoutPkBinder<'w, TRow> {
     pub fn bind<TTable>(self, table: TTable)
     where
         TRow: Send + Sync + Clone + InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        RowEvent<TRow>: Send + Sync,
         TTable: Table<
                 Row = TRow,
                 EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
@@ -115,7 +115,7 @@ impl<'w, TRow> ViewBinder<'w, TRow> {
     pub fn bind<TTable>(self, table: TTable)
     where
         TRow: Send + Sync + Clone + InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        RowEvent<TRow>: Send + Sync,
         TTable: Table<
                 Row = TRow,
                 EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
@@ -148,7 +148,7 @@ impl<'w, TRow> EventTableBinder<'w, TRow> {
     pub fn bind<TTable>(self, table: TTable)
     where
         TRow: Send + Sync + Clone + InModule + 'static,
-        crate::message::RowEvent<TRow>: Send + Sync,
+        RowEvent<TRow>: Send + Sync,
         TTable: Table<
                 Row = TRow,
                 EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
@@ -162,7 +162,7 @@ impl<'w, TRow> EventTableBinder<'w, TRow> {
 pub(crate) fn register_table<TRow>(app: &mut App)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
 {
     register_channel::<InsertMessage<TRow>>(app);
     register_channel::<DeleteMessage<TRow>>(app);
@@ -174,7 +174,7 @@ where
 pub(crate) fn register_table_without_pk<TRow>(app: &mut App)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
 {
     register_channel::<InsertMessage<TRow>>(app);
     register_channel::<DeleteMessage<TRow>>(app);
@@ -184,7 +184,7 @@ where
 pub(crate) fn register_view<TRow>(app: &mut App)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
 {
     register_table_without_pk::<TRow>(app);
 }
@@ -193,7 +193,7 @@ where
 pub(crate) fn register_event_table<TRow>(app: &mut App)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
 {
     register_channel::<InsertMessage<TRow>>(app);
 }
@@ -201,12 +201,12 @@ where
 fn bind_insert<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
     TTable: Table<
             Row = TRow,
             EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
         >,
-    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
+    TTable::EventContext: AbstractEventContext<Event = RowEvent<TRow>>,
 {
     let sender = channel_sender::<InsertMessage<TRow>>(world);
     table.on_insert(move |ctx, row| {
@@ -220,12 +220,12 @@ where
 fn bind_delete<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
     TTable: Table<
             Row = TRow,
             EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
         >,
-    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
+    TTable::EventContext: AbstractEventContext<Event = RowEvent<TRow>>,
 {
     let sender = channel_sender::<DeleteMessage<TRow>>(world);
     table.on_delete(move |ctx, row| {
@@ -239,12 +239,12 @@ where
 fn bind_update<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
     TTable: Table<
             Row = TRow,
             EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
         > + TableWithPrimaryKey<Row = TRow>,
-    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
+    TTable::EventContext: AbstractEventContext<Event = RowEvent<TRow>>,
 {
     let sender = channel_sender::<UpdateMessage<TRow>>(world);
     table.on_update(move |ctx, old, new| {
@@ -259,12 +259,12 @@ where
 fn bind_insert_update<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
-    crate::message::RowEvent<TRow>: Send + Sync,
+    RowEvent<TRow>: Send + Sync,
     TTable: Table<
             Row = TRow,
             EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
         > + TableWithPrimaryKey<Row = TRow>,
-    TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
+    TTable::EventContext: AbstractEventContext<Event = RowEvent<TRow>>,
 {
     let sender_insert = channel_sender::<InsertUpdateMessage<TRow>>(world);
     table.on_insert(move |ctx, row| {

--- a/src/table.rs
+++ b/src/table.rs
@@ -12,7 +12,7 @@ use crate::{
 use bevy_app::App;
 use bevy_ecs::prelude::World;
 use spacetimedb_sdk::{
-    __codegen::{AbstractEventContext, InModule},
+    __codegen::{AbstractEventContext, InModule, SpacetimeModule},
     EventTable, Table, TableWithPrimaryKey,
 };
 use std::marker::PhantomData;
@@ -49,8 +49,10 @@ impl<'w, TRow> TableBinder<'w, TRow> {
     where
         TRow: Send + Sync + Clone + InModule + 'static,
         crate::message::RowEvent<TRow>: Send + Sync,
-        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
-            + TableWithPrimaryKey<Row = TRow>,
+        TTable: Table<
+                Row = TRow,
+                EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+            > + TableWithPrimaryKey<Row = TRow>,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
         bind_delete::<TRow, TTable>(self.world, &table);
@@ -82,7 +84,10 @@ impl<'w, TRow> TableWithoutPkBinder<'w, TRow> {
     where
         TRow: Send + Sync + Clone + InModule + 'static,
         crate::message::RowEvent<TRow>: Send + Sync,
-        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
+        TTable: Table<
+                Row = TRow,
+                EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+            >,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
         bind_delete::<TRow, TTable>(self.world, &table);
@@ -112,7 +117,10 @@ impl<'w, TRow> ViewBinder<'w, TRow> {
     where
         TRow: Send + Sync + Clone + InModule + 'static,
         crate::message::RowEvent<TRow>: Send + Sync,
-        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
+        TTable: Table<
+                Row = TRow,
+                EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+            >,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
         bind_delete::<TRow, TTable>(self.world, &table);
@@ -142,8 +150,10 @@ impl<'w, TRow> EventTableBinder<'w, TRow> {
     where
         TRow: Send + Sync + Clone + InModule + 'static,
         crate::message::RowEvent<TRow>: Send + Sync,
-        TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
-            + EventTable,
+        TTable: Table<
+                Row = TRow,
+                EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+            > + EventTable,
     {
         bind_insert::<TRow, TTable>(self.world, &table);
     }
@@ -193,7 +203,10 @@ fn bind_insert<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
     crate::message::RowEvent<TRow>: Send + Sync,
-    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
+    TTable: Table<
+            Row = TRow,
+            EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+        >,
     TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender = channel_sender::<InsertMessage<TRow>>(world);
@@ -209,7 +222,10 @@ fn bind_delete<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
     crate::message::RowEvent<TRow>: Send + Sync,
-    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>,
+    TTable: Table<
+            Row = TRow,
+            EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+        >,
     TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender = channel_sender::<DeleteMessage<TRow>>(world);
@@ -225,8 +241,10 @@ fn bind_update<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
     crate::message::RowEvent<TRow>: Send + Sync,
-    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
-        + TableWithPrimaryKey<Row = TRow>,
+    TTable: Table<
+            Row = TRow,
+            EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+        > + TableWithPrimaryKey<Row = TRow>,
     TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender = channel_sender::<UpdateMessage<TRow>>(world);
@@ -243,8 +261,10 @@ fn bind_insert_update<TRow, TTable>(world: &World, table: &TTable)
 where
     TRow: Send + Sync + Clone + InModule + 'static,
     crate::message::RowEvent<TRow>: Send + Sync,
-    TTable: Table<Row = TRow, EventContext = <<TRow as InModule>::Module as spacetimedb_sdk::__codegen::SpacetimeModule>::EventContext>
-        + TableWithPrimaryKey<Row = TRow>,
+    TTable: Table<
+            Row = TRow,
+            EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
+        > + TableWithPrimaryKey<Row = TRow>,
     TTable::EventContext: AbstractEventContext<Event = crate::message::RowEvent<TRow>>,
 {
     let sender_insert = channel_sender::<InsertUpdateMessage<TRow>>(world);


### PR DESCRIPTION
## PR: Include SpacetimeDB event metadata in Bevy table messages

This PR improves the Bevy integration for SpacetimeDB table events by attaching the underlying event metadata to all emitted table messages.

### What changed

All table event message types now include an `event` field: `InsertMessage<T>`, `DeleteMessage<T>`, `UpdateMessage<T>`, `InsertUpdateMessage<T>`.

This field exposes the original SpacetimeDB event context for the row, making it possible to inspect metadata such as which reducer triggered the change.

To support this, the PR also introduces a new type alias: `RowEvent<T>`

`RowEvent<T>` resolves the event type associated with a given SpacetimeDB row type, so the event context remains strongly typed throughout the API.

### Why this is useful

Before this change, Bevy systems reacting to table messages only had access to the row data itself. With the new `event` field, handlers can also inspect the SpacetimeDB event that produced the insert, update, or delete.

That makes it much easier to:

- determine which reducer caused a row change
- inspect reducer metadata such as timestamps or status
- write event-aware gameplay and application logic directly in Bevy systems

### API updates

To make the event context available everywhere it is needed, this PR tightens the trait bounds on table binding and registration APIs.

These APIs now require:

- `T: InModule`
- `RowEvent<T>: Send + Sync`

This ensures that:

- the row type is associated with a module
- the corresponding event type is available
- the event context can be safely propagated through Bevy message handling

### Internal binding changes

The table event binding pipeline has been updated so event context is carried through all relevant callbacks and included whenever Bevy messages are emitted for: inserts, updates, insert_updates, and deletes.

This keeps the event metadata available end-to-end, rather than requiring users to reconstruct context themselves.


## Example
```rust
use crate::module_bindings::Reducer;
use bevy_stdb::prelude::*;
use spacetimedb_sdk::Event;

fn on_person_insert(mut messages: ReadInsertMessage<PersonRow>) {
  for msg in messages.read() {
    match &msg.event {
      Event::Reducer(r) => {
        // r.status
        // r.timestamp
        // r.reducer

        // which reducer caused this? You can also check out the args.
        match r.reducer {
          Reducer::CreatePerson(p) => {/**/}
        }
      },
      _ => ={ /*all others. See module code for all variants*/}
    }
  }
}
```