### PR TITLE
fix: manually bind insert for event table

### DIFF
--- a/src/table/bind.rs
+++ b/src/table/bind.rs
@@ -130,12 +130,20 @@ impl<'w, TRow> EventTableBinder<'w, TRow> {
     where
         TRow: Send + Sync + Clone + InModule + 'static,
         RowEvent<TRow>: Send + Sync,
-        TTable: Table<
+        TTable: EventTable<
                 Row = TRow,
                 EventContext = <<TRow as InModule>::Module as SpacetimeModule>::EventContext,
-            > + EventTable,
+            >,
     {
-        bind_insert::<TRow, TTable>(self.world, &table);
+        // bind_insert::<TRow, TTable>(self.world, &table);
+        // Temporarily inline this until spacetime is able to distinguish insert capabilities separately from event tables.
+        let sender = channel_sender::<InsertMessage<TRow>>(self.world);
+        table.on_insert(move |ctx, row| {
+            let _ = sender.send(InsertMessage {
+                event: ctx.event().clone(),
+                row: row.clone(),
+            });
+        });
     }
 }
 


### PR DESCRIPTION
Until we can distinguish between something that has insert capabilities and an EventTable, we cannot share bind_insert. So, this just duplicates the `bind_insert` function as inline for event tables. https://github.com/clockworklabs/SpacetimeDB/pull/4775 adds support for explicit capability traits. 