### PR TITLE
feat: set_token command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::connection::{PendingConnection, StdbConnection, StdbConnectionConfig};
 use bevy_ecs::{
-    prelude::{Commands, Res, World},
-    system::{Command, SystemParam},
+    prelude::{Command, Commands, ResMut, World},
+    system::SystemParam,
 };
 use bevy_tasks::IoTaskPool;
 use spacetimedb_sdk::{
@@ -66,7 +66,7 @@ where
     C: DbConnection<Module = M> + DbContext + Send + Sync + 'static,
     M: SpacetimeModule<DbConnection = C> + 'static,
 {
-    _config: Res<'w, StdbConnectionConfig<C, M>>,
+    config: ResMut<'w, StdbConnectionConfig<C, M>>,
     commands: Commands<'w, 's>,
 }
 
@@ -91,6 +91,14 @@ where
     /// Requests disconnection from the active SpacetimeDB connection.
     pub fn disconnect(&mut self) {
         self.commands.queue(DisconnectCommand::<C>::new());
+    }
+
+    /// Sets the authentication token in the SpacetimeDB connection config.
+    ///
+    /// This does not immediately reconnect with the new token but instead
+    /// will be used for future connection attempts.
+    pub fn set_token(&mut self, token: impl Into<String>) {
+        self.config.token = Some(token.into());
     }
 }
 


### PR DESCRIPTION
In preparation for [bevy_stdb_auth](https://github.com/onx2/bevy_stdb_auth) crate, we'll need some way to update the token without causing a reconnect. This exposes a command that will mutate the internal token for use in reconnects later on when needed.

So the general flow is something like:

- Listen for message that the access token has been refreshed from `bevy_stdb_auth`
- When refreshed, take the token and call `set_token` with it to update the state

When there is a disconnect + connect for spacetime, this new token will not be expired which means we can safely connect.


```rust
fn update_token(stdb_cmds: StdbCmds, msgs: ReadStdbAuthTokenRefreshedMessage) {
  for msg in msgs.read() {
    // new token from the active session... now subsequent reconnects will succeed
    // when the original token would have failed due to expiry.
    stdb_cmds.set_token(msg.session.access_token);
  }

}
```