### PR TITLE
fix: don't expose raw messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Each method eagerly registers the internal Bevy message channels for the row typ
 | Method | Use when |
 |---|---|
 | `add_table` | Table has a primary key — exposes insert, update, delete, and insert-or-update message readers |
-| `add_table_without_pk` | Table has no primary key — exposes insert and delete readers only |
-| `add_event_table` | Append-only log table — exposes insert message readers only |
+| `add_table_without_pk` | Table has no primary key — exposes insert and delete message readers |
+| `add_event_table` | Append-only log table — exposes insert message readers |
 | `add_view` | Server-computed virtual table — exposes insert and delete message readers |
 
 ```rust
@@ -190,14 +190,14 @@ Table event channel registration happens eagerly at startup; callback binding is
 
 ## Reading table events
 
-Depending on the table shape, systems consume database changes through read-only reader aliases:
+Depending on the table shape, systems consume database changes through MessageReader aliases:
 
 - `ReadInsertMessage<T>`
 - `ReadDeleteMessage<T>`
 - `ReadUpdateMessage<T>`
 - `ReadInsertUpdateMessage<T>`
 
-These aliases are `MessageReader`s backed by internal message channels. The message types themselves are not part of the public API, so application code can observe table events without writing them directly. Values yielded by `.read()` still expose the affected row data and the SpacetimeDB event that triggered the change.
+These aliases are `MessageReader`s backed by internal message channels. The message types themselves are not part of the public API, so application code can observe table events without writing them directly. Values yielded by `.read()` expose the affected row data and the SpacetimeDB event that triggered the change.
 
 ```rust
 use crate::module_bindings::Reducer;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A [Bevy](https://bevy.org/) integration for [SpacetimeDB](https://spacetimedb.co
 - **Builder-style setup** via `StdbPlugin`
 - **Connection resource** access through `StdbConnection`
 - **Command interface** for sending SpacetimeDB commands through `StdbCmds`
-- **Table event bridging** into normal Bevy `Message`s
+- **Table event bridging** through Bevy `MessageReader` aliases
 - **Managed subscription intent** through `StdbSubscriptions`
 - **Optional reconnect support** through `StdbReconnectOptions`
 
@@ -170,14 +170,14 @@ fn main() {
 
 Use the `StdbPlugin` builder methods to register table bindings during app setup.
 
-Each method eagerly registers the Bevy message channels for the row type you specify and stores a deferred binding callback that runs whenever a connection becomes active.
+Each method eagerly registers the internal Bevy message channels for the row type you specify and stores a deferred binding callback that runs whenever a connection becomes active.
 
 | Method | Use when |
 |---|---|
-| `add_table` | Table has a primary key — emits insert, update, and delete messages |
-| `add_table_without_pk` | Table has no primary key — emits insert and delete messages only |
-| `add_event_table` | Append-only log table — emits insert messages only |
-| `add_view` | Server-computed virtual table — emits insert and delete messages |
+| `add_table` | Table has a primary key — exposes insert, update, delete, and insert-or-update message readers |
+| `add_table_without_pk` | Table has no primary key — exposes insert and delete readers only |
+| `add_event_table` | Append-only log table — exposes insert message readers only |
+| `add_view` | Server-computed virtual table — exposes insert and delete message readers |
 
 ```rust
 .add_table::<PlayerInfo>(|reg, db| reg.bind(db.player_info()))
@@ -186,18 +186,18 @@ Each method eagerly registers the Bevy message channels for the row type you spe
 .add_view::<NearbyMonster>(|reg, db| reg.bind(db.nearby_monsters()))
 ```
 
-Table message registration happens eagerly at startup; callback binding is deferred until a connection is active.
+Table event channel registration happens eagerly at startup; callback binding is deferred until a connection is active.
 
-## Messages
+## Reading table events
 
-Depending on the table shape, `bevy_stdb` forwards updates into Bevy messages such as:
+Depending on the table shape, systems consume database changes through read-only reader aliases:
 
-- `InsertMessage<T>`
-- `DeleteMessage<T>`
-- `UpdateMessage<T>`
-- `InsertUpdateMessage<T>`
+- `ReadInsertMessage<T>`
+- `ReadDeleteMessage<T>`
+- `ReadUpdateMessage<T>`
+- `ReadInsertUpdateMessage<T>`
 
-This lets normal Bevy systems react to database changes using message readers. These messages include both the affected row data and the SpacetimeDB event that triggered the change.
+These aliases are `MessageReader`s backed by internal message channels. The message types themselves are not part of the public API, so application code can observe table events without writing them directly. Values yielded by `.read()` still expose the affected row data and the SpacetimeDB event that triggered the change.
 
 ```rust
 use crate::module_bindings::Reducer;
@@ -256,7 +256,7 @@ When a reconnect succeeds:
 - the `StdbConnection` resource is replaced
 - table callbacks are re-bound
 - subscriptions are re-applied
-- 
+
 ## Using commands
 
 Use `StdbCommands<C, M>` to connect or disconnect at runtime, optionally overriding the token, URI, or database name configured on the plugin.
@@ -323,16 +323,16 @@ Subscriptions are required to tell Spacetime which table data you want to sync t
 That means you can:
 
 - enable subscription management during plugin setup using `with_subscriptions`
-- queue subscriptions later from normal Bevy systems, typically in response to `StdbConnectedMessage`
+- queue subscriptions later from normal Bevy systems, typically by reading `ReadStdbConnectedMessage`
 - automatically re-apply queued subscription intent after reconnect
 
 Subscriptions are keyed, so you can refer to them using domain-specific identifiers to do things like resubscribe dynamically or unsubscribe. 
 
-There are also messages that are emitted for the `on_applied` and `on_error` callbacks for each subscription. 
+Subscription callbacks are exposed through `ReadStdbSubscriptionAppliedMessage<K>` and `ReadStdbSubscriptionErrorMessage<K>`.
 
 ```rust
 // Check the client cache once a particular subscription has been applied.
-fn on_applied(mut applied_msgs: ReadStdbSubscriptionAppliedMessage<SubKey>, conn: Res<StdbConn>) {
+fn on_applied(mut applied_messages: ReadStdbSubscriptionAppliedMessage<SubKey>, conn: Res<StdbConn>) {
   for message in applied_messages.read() {
     if message.is(&SubKey::MyCharacters) {
       println!("You have {} characters.", conn.db().my_characters().count());
@@ -372,6 +372,6 @@ fn example_system(conn: Res<StdbConn>, mut subs: ResMut<StdbSubs>) {
 
 ## Notes
 
-This crate focuses on table-driven client workflows. Reducer and procedure access still exist through the active `StdbConnection`, but the primary Bevy-facing event flow is table/message based.
+This crate focuses on table-driven client workflows. Reducer and procedure access still exist through the active `StdbConnection`, but the primary Bevy-facing event flow uses table event readers.
 
 Special thanks to [`bevy_spacetimedb`](https://docs.rs/bevy_spacetimedb/) for the inspiration!

--- a/README.md
+++ b/README.md
@@ -372,6 +372,6 @@ fn example_system(conn: Res<StdbConn>, mut subs: ResMut<StdbSubs>) {
 
 ## Notes
 
-This crate focuses on table-driven client workflows. Reducer and procedure access still exist through the active `StdbConnection`, but the primary Bevy-facing event flow uses table event readers.
+This crate focuses on table-driven client workflows. Reducer and procedure access still exist through the active `StdbConnection`, but the primary Bevy-facing flow uses message readers for table events.
 
 Special thanks to [`bevy_spacetimedb`](https://docs.rs/bevy_spacetimedb/) for the inspiration!

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,4 +1,4 @@
-//! [`MessageReader`] type aliases for connection lifecycle and table messages.
+//! Read-only [`MessageReader`] aliases for connection lifecycle and table events.
 use crate::message::{
     DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectErrorMessage,
     StdbConnectedMessage, StdbDisconnectedMessage, StdbSubscriptionAppliedMessage,
@@ -6,31 +6,31 @@ use crate::message::{
 };
 use bevy_ecs::prelude::MessageReader;
 
-/// A [`MessageReader`] for [`InsertMessage<T>`].
+/// Reads insert events for rows of `T`.
 pub type ReadInsertMessage<'w, 's, T> = MessageReader<'w, 's, InsertMessage<T>>;
 
-/// A [`MessageReader`] for [`UpdateMessage<T>`].
+/// Reads update events for rows of `T`.
 pub type ReadUpdateMessage<'w, 's, T> = MessageReader<'w, 's, UpdateMessage<T>>;
 
-/// A [`MessageReader`] for [`DeleteMessage<T>`].
+/// Reads delete events for rows of `T`.
 pub type ReadDeleteMessage<'w, 's, T> = MessageReader<'w, 's, DeleteMessage<T>>;
 
-/// A [`MessageReader`] for [`InsertUpdateMessage<T>`].
+/// Reads insert-or-update events for rows of `T`.
 pub type ReadInsertUpdateMessage<'w, 's, T> = MessageReader<'w, 's, InsertUpdateMessage<T>>;
 
-/// A [`MessageReader`] for [`StdbConnectedMessage`].
+/// Reads successful SpacetimeDB connections.
 pub type ReadStdbConnectedMessage<'w, 's> = MessageReader<'w, 's, StdbConnectedMessage>;
 
-/// A [`MessageReader`] for [`StdbDisconnectedMessage`].
+/// Reads closed or lost SpacetimeDB connections.
 pub type ReadStdbDisconnectedMessage<'w, 's> = MessageReader<'w, 's, StdbDisconnectedMessage>;
 
-/// A [`MessageReader`] for [`StdbConnectErrorMessage`].
+/// Reads failed SpacetimeDB connection attempts.
 pub type ReadStdbConnectErrorMessage<'w, 's> = MessageReader<'w, 's, StdbConnectErrorMessage>;
 
-/// A [`MessageReader`] for [`StdbSubscriptionAppliedMessage<K>`].
+/// Reads successful subscription applications keyed by `K`.
 pub type ReadStdbSubscriptionAppliedMessage<'w, 's, K> =
     MessageReader<'w, 's, StdbSubscriptionAppliedMessage<K>>;
 
-/// A [`MessageReader`] for [`StdbSubscriptionErrorMessage<K>`].
+/// Reads failed subscription applications keyed by `K`.
 pub type ReadStdbSubscriptionErrorMessage<'w, 's, K> =
     MessageReader<'w, 's, StdbSubscriptionErrorMessage<K>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Bevy integration for [SpacetimeDB](https://spacetimedb.com).
 //!
 //! `bevy_stdb` adapts SpacetimeDB's connection and callback model into
-//! Bevy-style resources, systems, and messages. Everything is configured
-//! through [`StdbPlugin`](crate::prelude::StdbPlugin).
+//! Bevy-style resources, systems, and read-only message readers. Everything is
+//! configured through [`StdbPlugin`](crate::prelude::StdbPlugin).
 //!
 //! # Architecture
 //!
@@ -11,13 +11,14 @@
 //! - **Connection** — Manage the connection lifecycle on demand via
 //!   [`StdbCommands`](crate::prelude::StdbCommands), and expose the active
 //!   connection as [`StdbConnection`](crate::prelude::StdbConnection).
-//! - **Tables** — Register message channels once at startup and re-bind SDK
-//!   table callbacks whenever a connection becomes active. Row changes are
-//!   forwarded as Bevy [`Message`](bevy_ecs::prelude::Message)s
-//!   ([`InsertMessage`](crate::prelude::InsertMessage),
-//!   [`DeleteMessage`](crate::prelude::DeleteMessage),
-//!   [`UpdateMessage`](crate::prelude::UpdateMessage),
-//!   [`InsertUpdateMessage`](crate::prelude::InsertUpdateMessage)).
+//! - **Tables** — Register internal channels for Bevy
+//!   [`Message`](bevy_ecs::prelude::Message) values once at startup and
+//!   re-bind SDK table callbacks whenever a connection becomes active. Row
+//!   changes are consumed through read-only reader aliases such as
+//!   [`ReadInsertMessage`](crate::prelude::ReadInsertMessage),
+//!   [`ReadDeleteMessage`](crate::prelude::ReadDeleteMessage),
+//!   [`ReadUpdateMessage`](crate::prelude::ReadUpdateMessage), and
+//!   [`ReadInsertUpdateMessage`](crate::prelude::ReadInsertUpdateMessage).
 //! - **Subscriptions** — Store subscription intent separately from the live
 //!   connection via [`StdbSubscriptions`](crate::prelude::StdbSubscriptions)
 //!   so queries are automatically re-applied after reconnects.
@@ -102,11 +103,6 @@ pub mod prelude {
         },
         commands::{StdbCommands, StdbConnectOptions},
         connection::{StdbConnection, StdbReconnectOptions},
-        message::{
-            DeleteMessage, InsertMessage, InsertUpdateMessage, StdbConnectErrorMessage,
-            StdbConnectedMessage, StdbDisconnectedMessage, StdbSubscriptionAppliedMessage,
-            StdbSubscriptionErrorMessage, UpdateMessage,
-        },
         plugin::StdbPlugin,
         set::StdbSet,
         subscription::StdbSubscriptions,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -340,8 +340,8 @@ impl<C: DbConnection<Module = M> + DbContext + Send + Sync, M: SpacetimeModule<D
     ///
     /// This installs [`crate::subscription::StdbSubscriptions`] as a Bevy
     /// resource so subscriptions can be queued at runtime from normal Bevy
-    /// systems, for example in response to
-    /// [`crate::prelude::StdbConnectedMessage`].
+    /// systems, for example with
+    /// [`ReadStdbConnectedMessage`](crate::prelude::ReadStdbConnectedMessage).
     ///
     /// # Example
     ///

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,10 +1,7 @@
 //! Table registration and message forwarding for SpacetimeDB.
 //!
-//! Registers Bevy message channels and binds SDK table callbacks to
-//! forward events as [`InsertMessage`](crate::message::InsertMessage),
-//! [`UpdateMessage`](crate::message::UpdateMessage),
-//! [`DeleteMessage`](crate::message::DeleteMessage), and
-//! [`InsertUpdateMessage`](crate::message::InsertUpdateMessage).
+//! Registers internal Bevy [`Message`](bevy_ecs::prelude::Message) channels
+//! and binds SDK table callbacks for row event readers.
 mod bind;
 mod register;
 


### PR DESCRIPTION
When the raw messages are exposed, the consumer is able to freely write messages which bypasses internal systems leading to unexpected behaviors. This PR scopes the public API to the valid choices... reading through aliased messages and writing through commands.