### PR TITLE
chore: Update compatibility table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,10 +365,10 @@ fn example_system(conn: Res<StdbConn>, mut subs: ResMut<StdbSubs>) {
 
 ## Compatibility
 
-| bevy_stdb  | bevy   | spacetimedb_sdk |
-| ---------- | ------ | --------------- |
-| <  0.12    | 0.18   | 2               |
-| >= 0.12    | 0.19   | 2               |
+| bevy_stdb | bevy   | spacetimedb_sdk | MSRV |
+| --------- | ------ | --------------- | ---- |
+| 0.1 - 0.8 | 0.18   | 2.x             | 1.93 |
+|      0.12 | 0.19   | 2.x             | 1.95 |
 
 
 ## Notes


### PR DESCRIPTION
- More explicit versions in compat chart. there isn't a v0.9-0.11 b/c I messed up publishing
- MSRV is now listed. bevy 0.19 required a bump to 1.95. As of writing this, the latest is 1.96. This repo tests against msrv + stable rust versions